### PR TITLE
Make testing compatible with different PyTorch Lightning versions

### DIFF
--- a/src/train.py
+++ b/src/train.py
@@ -10,7 +10,7 @@ from pytorch_lightning.callbacks.model_checkpoint import ModelCheckpoint
 try:
     from pytorch_lightning.plugins import DDPPlugin
 except ImportError:
-    # compatibility for older PyTorch lightning versions
+    # compatibility for PyTorch Lightning versions < 1.2.0
     from pytorch_lightning.plugins.ddp_plugin import DDPPlugin
 
 from utils import LoadFromFile, save_argparse


### PR DESCRIPTION
PyTorch Lightning changed the way of setting the trainer state from version 1.1.x to 1.2.x so a change in the way we evaluate the test set had to be made. It now works with PL 1.1.x and 1.2.x. This also fixes issue #2 .