### PR TITLE
Implement atom filter in output network

### DIFF
--- a/scripts/train.py
+++ b/scripts/train.py
@@ -75,6 +75,7 @@ def get_args():
     parser.add_argument('--derivative', default=False, type=bool, help='If true, take the derivative of the prediction w.r.t coordinates')
     parser.add_argument('--cutoff-lower', type=float, default=0.0, help='Lower cutoff in model')
     parser.add_argument('--cutoff-upper', type=float, default=5.0, help='Upper cutoff in model')
+    parser.add_argument('--atom-filter', type=int, default=0, help='Only sum over atoms with Z > atom_filter')
     # fmt: on
  
     args = parser.parse_args()

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -10,7 +10,8 @@ def create_model(args):
         neighbor_embedding=args.neighbor_embedding,
         cutoff_lower=args.cutoff_lower,
         cutoff_upper=args.cutoff_upper,
-        derivative=args.derivative
+        derivative=args.derivative,
+        atom_filter=args.atom_filter
     )
 
     if args.model == 'graph-network':


### PR DESCRIPTION
Filter out atoms with an atomic number z <= `atom_filter` before the atomwise output network.