### PR TITLE
Feat/cgnet nec4

### DIFF
--- a/torchmdnet2/nn/__init__.py
+++ b/torchmdnet2/nn/__init__.py
@@ -1,3 +1,3 @@
-from .torchmd_gn import TorchMD_GN
+from .torchmd_gn import TorchMD_GN, GraphNormMSE
 from .priors import RepulsionLayer, HarmonicLayer, BaselineModel
 from .cgnet import CGnet

--- a/torchmdnet2/nn/torchmd_gn.py
+++ b/torchmdnet2/nn/torchmd_gn.py
@@ -202,7 +202,7 @@ class TorchMD_GN(torch.nn.Module):
 
 class InteractionBlock(torch.nn.Module):
     def __init__(self, hidden_channels, num_rbf, num_filters, activation,
-                  	cutoff_lower, cutoff_upper, cfconv_aggr='mean'):
+                      cutoff_lower, cutoff_upper, cfconv_aggr='mean'):
         super(InteractionBlock, self).__init__()
         self.mlp = Sequential(
             Linear(num_rbf, num_filters),
@@ -360,6 +360,33 @@ class CosineCutoff(torch.nn.Module):
             # remove contributions beyond the cutoff radius
             cutoffs = cutoffs * (distances < self.cutoff_upper).float()
             return cutoffs
+
+
+class GraphNormMSE(torch.nn.Module):
+    def __init__(self):
+        super(GraphNormMSE, self).__init__()
+
+    def forward(self, pred_prop, prop, batch):
+        """Calculation of the MSE loss per graph.
+
+        Args:
+            pred_prop (torch.tensor): property predicted by the
+                model, with shape (n_examples, **dims)
+            prop (torch.tensor): labeled property that the model
+                is attempting to match, with shape (n_examples, **dims)
+            batch (torch.tensor): batch indices, as supplied by
+                pytorch geometric dataloader, with shape (n_examples)
+        Returns:
+            loss (torch.tensor): MSE loss per graph, where each example
+                has been normalized by the size of the graph from which
+                it originated. Shape (1); scalar.
+        """
+        node_idx, node_sizes = torch.unique(batch, return_counts=True)
+        example_sizes = node_sizes[batch]
+        prop_diff = prop - pred_prop
+        prop_diff = prop_diff * example_sizes[:, None]
+        loss = (prop_diff**2).mean()
+        return loss
 
 
 rbf_class_mapping = {


### PR DESCRIPTION
Hello! I have added a few utilities:

1. A `TorchMD_GN` kwarg that allows users to set the `CFConv` aggr kwarg from the initialization of the `TorchMD_GN` class.
2. A `TorchMD_GN` kwarg that allows users to the size of the embedding dictionary. Previously, this was hard-coded to 100.
3. A loss function `GraphNormMSE` that allows uses to perform MSE property matching but normalize each example by the size of the graph that it belongs to. This can be useful, for example, if one is training on a dataset with many molecules that may have vastly different sizes.

I have also added tests for these new utilities. I have opted for `nosetests` out of personal preference, but if you prefer something else, we can change it. Let me know if the documentation is not clear, or if there are any changes you would like to make!