### PR TITLE
fixed GraphNormMSE example size division error

### DIFF
--- a/torchmdnet2/nn/torchmd_gn.py
+++ b/torchmdnet2/nn/torchmd_gn.py
@@ -384,7 +384,7 @@ class GraphNormMSE(torch.nn.Module):
         node_idx, node_sizes = torch.unique(batch, return_counts=True)
         example_sizes = node_sizes[batch]
         prop_diff = prop - pred_prop
-        prop_diff = prop_diff * example_sizes[:, None]
+        prop_diff = prop_diff / example_sizes[:, None]
         loss = (prop_diff**2).mean()
         return loss
 

--- a/torchmdnet2/tests/test_gn.py
+++ b/torchmdnet2/tests/test_gn.py
@@ -59,7 +59,7 @@ def test_graph_norm_loss():
                          torch.tensor(graph_labels))
 
     numpy_loss = random_force_data - random_force_labels
-    numpy_loss = numpy_loss * np.array(size_labels)[:, None]
+    numpy_loss = numpy_loss / np.array(size_labels)[:, None]
     numpy_loss = (numpy_loss ** 2).mean()
 
     np.testing.assert_allclose(numpy_loss, torch_loss.numpy(),


### PR DESCRIPTION
This PR fixes a division error in the `GraphNormMSE` (previously the force difference was multiplied by the graph size instead of being divided by it).