### PR TITLE
Base learning rate decay on training loss

### DIFF
--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -32,7 +32,7 @@ class LNNP(LightningModule):
                                       patience=self.hparams.lr_patience,
                                       min_lr=self.hparams.lr_min)
         lr_scheduler = {'scheduler': scheduler,
-                        'monitor': 'val_loss',
+                        'monitor': 'train_loss',
                         'interval': 'epoch',
                         'frequency': 1}
         return [optimizer], [lr_scheduler]


### PR DESCRIPTION
This changes it to base learning rate decay on training loss rather than validation loss.  That gives a much cleaner signal for whether it is still learning.  The practical effect is that you can use a smaller value for `lr_patience`, which leads to faster training.

In general, training loss tells you whether it is learning, and the difference between training loss and validation loss tells you whether it is overfitting.  If the training loss stops decreasing, that means you need to reduce the learning rate.  If the training loss is still decreasing but the validation loss stops going down, that means it is overfitting and you should stop.  Reducing the learning rate won't help.