### PR TITLE
added alpha scaling in expnorm and visualization function

### DIFF
--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -20,6 +20,8 @@ def visualize_basis(basis_type, num_rbf=50, cutoff_lower=0, cutoff_upper=5):
         cutoff_upper (float, optional): The upper cutoff of the basis.
             (default: :obj:`5`)
     """
+    import matplotlib.pyplot as plt
+
     distances = torch.linspace(cutoff_lower-1, cutoff_upper+1, 1000) 
     basis_kwargs = {'num_rbf':num_rbf, 'cutoff_lower':cutoff_lower, 'cutoff_upper':cutoff_upper}
     basis_expansion = rbf_class_mapping[basis_type](**basis_kwargs)


### PR DESCRIPTION
Hello,

This PR adds the "alpha scaling" described in #28. The parameter is chosen directly from the upper and lower cutoffs only, so it should work with the normal basis function flow that the model initialization currently uses. I also added a utility function, `visualize_basis` that helps visualize gaussian or expnormal bases for debugging purposes. Let me know if there are any changes needed or things to add/remove. 