### PR TITLE
Make sure self loops are kept with lower cutoff

### DIFF
--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,0 +1,62 @@
+from os.path import join, exists
+from pytest import mark, raises
+import torch
+from torchmdnet.models.utils import Distance
+
+
+@mark.parametrize("cutoff_lower", [0, 2])
+@mark.parametrize("cutoff_upper", [5, 10])
+@mark.parametrize("return_vecs", [False, True])
+@mark.parametrize("loop", [False, True])
+def test_distance_calculation(cutoff_lower, cutoff_upper, return_vecs, loop):
+    dist = Distance(
+        cutoff_lower,
+        cutoff_upper,
+        max_num_neighbors=100,
+        return_vecs=return_vecs,
+        loop=loop,
+    )
+
+    batch = torch.tensor([0, 0])
+
+    loop_extra = len(batch) if loop else 0
+
+    # two atoms, distance between lower and upper cutoff
+    pos = torch.tensor(
+        [[0, 0, 0], [(cutoff_lower + cutoff_upper) / 2, 0, 0]], dtype=torch.float
+    )
+    edge_index, edge_weight, edge_vec = dist(pos, batch)
+    assert (
+        edge_index.size(1) == 2 + loop_extra
+    ), "Didn't return right number of neighbors"
+
+    # check return_vecs
+    if return_vecs:
+        assert (
+            edge_vec is not None
+        ), "Edge vectors were requested but Distance returned None"
+
+    # two atoms, distance lower than lower cutoff
+    if cutoff_lower > 0:
+        pos = torch.tensor([[0, 0, 0], [cutoff_lower / 2, 0, 0]], dtype=torch.float)
+        edge_index, edge_weight, edge_vec = dist(pos, batch)
+        assert edge_index.size(1) == loop_extra, "Returned too many neighbors"
+
+    # two atoms, distance larger than upper cutoff
+    pos = torch.tensor([[0, 0, 0], [cutoff_upper + 1, 0, 0]], dtype=torch.float)
+    edge_index, edge_weight, edge_vec = dist(pos, batch)
+    assert edge_index.size(1) == loop_extra, "Returned too many neighbors"
+
+    # check large number of atoms
+    batch = torch.zeros(100, dtype=torch.long)
+    pos = torch.rand(100, 3)
+    edge_index, edge_weight, edge_vec = dist(pos, batch)
+
+    loop_extra = len(batch) if loop else 0
+
+    if cutoff_lower > 0:
+        assert edge_index.size(1) == loop_extra, "Expected only self loops"
+    else:
+        assert edge_index.size(1) == (
+            len(batch) * (len(batch) - 1) + loop_extra
+        ), "Expected all neighbors to match"

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -1,4 +1,5 @@
 import math
+from typing import Optional
 import torch
 from torch import nn
 import torch.nn.functional as F
@@ -216,6 +217,7 @@ class Distance(nn.Module):
         )
         edge_vec = pos[edge_index[0]] - pos[edge_index[1]]
 
+        mask : Optional[torch.Tensor]=None
         if self.loop:
             # mask out self loops when computing distances because
             # the norm of 0 produces NaN gradients
@@ -227,6 +229,9 @@ class Distance(nn.Module):
             edge_weight = torch.norm(edge_vec, dim=-1)
 
         lower_mask = edge_weight >= self.cutoff_lower
+        if self.loop and mask is not None:
+            # keep self loops even though they might be below the lower cutoff
+            lower_mask = lower_mask | ~mask
         edge_index = edge_index[:, lower_mask]
         edge_weight = edge_weight[lower_mask]
 


### PR DESCRIPTION
Currently self loops in the distance calculation (needed for self-attention in ET) are dropped if the lower cutoff is > 0. We now explicitly keep the self loops.