### PR TITLE
Throw error if max_num_neighbors is too small

### DIFF
--- a/tests/test_model_utils.py
+++ b/tests/test_model_utils.py
@@ -1,4 +1,4 @@
-from pytest import mark
+from pytest import mark, raises
 import torch
 from torch.autograd import grad
 from torchmdnet.models.model import create_model
@@ -62,6 +62,26 @@ def test_distance_calculation(cutoff_lower, cutoff_upper, return_vecs, loop):
         assert edge_index.size(1) == (
             len(batch) * (len(batch) - 1) + loop_extra
         ), "Expected all neighbors to match"
+
+
+def test_neighbor_count_error():
+    dist = Distance(0, 5, max_num_neighbors=32)
+
+    # single molecule that should produce an error due to exceeding
+    # the maximum number of neighbors
+    pos = torch.rand(100, 3)
+    batch = torch.zeros(pos.size(0), dtype=torch.long)
+
+    with raises(AssertionError):
+        dist(pos, batch)
+
+    # example data where the second molecule should produce an error
+    # due to exceeding the maximum number of neighbors
+    pos = torch.rand(100, 3)
+    batch = torch.tensor([0] * 20 + [1] * 80, dtype=torch.long)
+
+    with raises(AssertionError):
+        dist(pos, batch)
 
 
 def test_gated_eq_gradients():

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -214,8 +214,17 @@ class Distance(nn.Module):
             r=self.cutoff_upper,
             batch=batch,
             loop=self.loop,
-            max_num_neighbors=self.max_num_neighbors,
+            max_num_neighbors=self.max_num_neighbors + 1,
         )
+
+        # make sure we didn't miss any neighbors due to max_num_neighbors
+        assert not (
+            edge_index[0].unique(return_counts=True)[1] > self.max_num_neighbors
+        ).any(), (
+            "The neighbor search missed some atoms due to max_num_neighbors being too low. "
+            "Please increase this parameter to fit your largest molecule."
+        )
+
         edge_vec = pos[edge_index[0]] - pos[edge_index[1]]
 
         mask : Optional[torch.Tensor]=None

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -219,7 +219,7 @@ class Distance(nn.Module):
 
         # make sure we didn't miss any neighbors due to max_num_neighbors
         assert not (
-            edge_index[0].unique(return_counts=True)[1] > self.max_num_neighbors
+            torch.unique(edge_index[0], return_counts=True)[1] > self.max_num_neighbors
         ).any(), (
             "The neighbor search missed some atoms due to max_num_neighbors being too low. "
             "Please increase this parameter to fit your largest molecule."

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -222,7 +222,7 @@ class Distance(nn.Module):
             torch.unique(edge_index[0], return_counts=True)[1] > self.max_num_neighbors
         ).any(), (
             "The neighbor search missed some atoms due to max_num_neighbors being too low. "
-            "Please increase this parameter to fit your largest molecule."
+            "Please increase this parameter to include the maximum number of atoms within the cutoff."
         )
 
         edge_vec = pos[edge_index[0]] - pos[edge_index[1]]


### PR DESCRIPTION
This adds an assertion to the neighbor search, which makes sure that no atoms are being missed due to a too small `max_num_neighbors` parameter.