### PR TITLE
Handle when load_model is specified twice

### DIFF
--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -103,6 +103,16 @@ class LoadFromFile(argparse.Action):
             for key in config.keys():
                 if key not in namespace:
                     raise ValueError(f"Unknown argument in config file: {key}")
+            if (
+                "load_model" in config
+                and namespace.load_model is not None
+                and config["load_model"] != namespace.load_model
+            ):
+                rank_zero_warn(
+                    f"The load model argument was specified as a command line argument "
+                    f"({namespace.load_model}) and in the config file ({config['load_model']}). "
+                    f"Ignoring 'load_model' from the config file and loading {namespace.load_model}."
+                )
             namespace.__dict__.update(config)
         else:
             raise ValueError("Configuration file must end with yaml or yml")

--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -113,6 +113,7 @@ class LoadFromFile(argparse.Action):
                     f"({namespace.load_model}) and in the config file ({config['load_model']}). "
                     f"Ignoring 'load_model' from the config file and loading {namespace.load_model}."
                 )
+                del config["load_model"]
             namespace.__dict__.update(config)
         else:
             raise ValueError("Configuration file must end with yaml or yml")


### PR DESCRIPTION
Currently the config file overwrites the `load_model` argument from the command line, if specified. It would be more intuitive if the command line argument overwrites the config file as this matches the behavior of all other arguments. Now we show a warning if `load_model` is specified twice and the two arguments differ and we ignore `load_model` in the config file.