### PR TITLE
Implement mol_id for the loaders

### DIFF
--- a/torchmdnet/datasets/ani.py
+++ b/torchmdnet/datasets/ani.py
@@ -24,7 +24,7 @@ class ANIBase(Dataset):
         energy = sum(self.ELEMENT_ENERGIES[z] for z in atomic_numbers)
         return energy * ANIBase.HARTREE_TO_EV
 
-    def sample_iter(self):
+    def sample_iter(self, mol_ids=False):
         raise NotImplementedError()
 
     def get_atomref(self, max_z=100):
@@ -188,14 +188,14 @@ class ANI1(ANIBase):
         extract_tar(archive, self.raw_dir)
         os.remove(archive)
 
-    def sample_iter(self):
+    def sample_iter(self, mol_ids=False):
 
         atomic_numbers = {b"H": 1, b"C": 6, b"N": 7, b"O": 8}
 
         for path in tqdm(self.raw_paths, desc="Files"):
-            molecules = list(h5py.File(path).values())[0].values()
+            molecules = list(h5py.File(path).values())[0].items()
 
-            for mol in tqdm(molecules, desc="Molecules", leave=False):
+            for mol_id, mol in tqdm(molecules, desc="Molecules", leave=False):
                 z = pt.tensor(
                     [atomic_numbers[atom] for atom in mol["species"]], dtype=pt.long
                 )
@@ -209,7 +209,13 @@ class ANI1(ANIBase):
                 assert all_pos.shape[2] == 3
 
                 for pos, y in zip(all_pos, all_y):
-                    data = Data(z=z, pos=pos, y=y.view(1, 1))
+
+                    # Create a sample
+                    args = dict(z=z, pos=pos, y=y.view(1, 1))
+                    if mol_ids:
+                        args["mol_id"] = mol_id
+                    data = Data(**args)
+
                     if data := self.filter_and_pre_transform(data):
                         yield data
 
@@ -264,12 +270,12 @@ class ANI1X(ANI1XBase):
         8: -75.0362229210,
     }
 
-    def sample_iter(self):
+    def sample_iter(self, mol_ids=False):
 
         assert len(self.raw_paths) == 1
 
         with h5py.File(self.raw_paths[0]) as h5:
-            for mol in tqdm(h5.values(), desc="Molecules"):
+            for mol_id, mol in tqdm(h5.items(), desc="Molecules"):
 
                 z = pt.tensor(mol["atomic_numbers"][:], dtype=pt.long)
                 all_pos = pt.tensor(mol["coordinates"][:], dtype=pt.float32)
@@ -293,7 +299,12 @@ class ANI1X(ANI1XBase):
                     if y.isnan() or dy.isnan().any():
                         continue
 
-                    data = Data(z=z, pos=pos, y=y.view(1, 1), dy=dy)
+                    # Create a sample
+                    args = dict(z=z, pos=pos, y=y.view(1, 1), dy=dy)
+                    if mol_ids:
+                        args["mol_id"] = mol_id
+                    data = Data(**args)
+
                     if data := self.filter_and_pre_transform(data):
                         yield data
 
@@ -309,12 +320,13 @@ class ANI1X(ANI1XBase):
 
 
 class ANI1CCX(ANI1XBase):
-    def sample_iter(self):
+
+    def sample_iter(self, mol_ids=False):
 
         assert len(self.raw_paths) == 1
 
         with h5py.File(self.raw_paths[0]) as h5:
-            for mol in tqdm(h5.values(), desc="Molecules"):
+            for mol_id, mol in tqdm(h5.items(), desc="Molecules"):
 
                 z = pt.tensor(mol["atomic_numbers"][:], dtype=pt.long)
                 all_pos = pt.tensor(mol["coordinates"][:], dtype=pt.float32)
@@ -331,7 +343,12 @@ class ANI1CCX(ANI1XBase):
                     if y.isnan():
                         continue
 
-                    data = Data(z=z, pos=pos, y=y.view(1, 1))
+                    # Create a sample
+                    args = dict(z=z, pos=pos, y=y.view(1, 1))
+                    if mol_ids:
+                        args["mol_id"] = mol_id
+                    data = Data(**args)
+
                     if data := self.filter_and_pre_transform(data):
                         yield data
 

--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -83,12 +83,12 @@ class COMP6Base(Dataset):
             f"{self.name}.dy.mmap",
         ]
 
-    def sample_iter(self):
+    def sample_iter(self, mol_ids=False):
 
         for path in tqdm(self.raw_paths, desc="Files"):
-            molecules = list(h5py.File(path).values())[0].values()
+            molecules = list(h5py.File(path).values())[0].items()
 
-            for mol in tqdm(molecules, desc="Molecules", leave=False):
+            for mol_id, mol in tqdm(molecules, desc="Molecules", leave=False):
                 z = pt.tensor(
                     [self.ATOMIC_NUMBERS[atom] for atom in mol["species"]],
                     dtype=pt.long,
@@ -111,7 +111,10 @@ class COMP6Base(Dataset):
                 assert all_dy.shape[2] == 3
 
                 for pos, y, dy in zip(all_pos, all_y, all_dy):
-                    data = Data(z=z, pos=pos, y=y.view(1, 1), dy=dy)
+                    if mol_ids:
+                        data = Data(mol_id=mol_id, z=z, pos=pos, y=y.view(1, 1), dy=dy)
+                    else:
+                        data = Data(z=z, pos=pos, y=y.view(1, 1), dy=dy)
 
                     if self.pre_filter is not None and not self.pre_filter(data):
                         continue

--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -111,10 +111,12 @@ class COMP6Base(Dataset):
                 assert all_dy.shape[2] == 3
 
                 for pos, y, dy in zip(all_pos, all_y, all_dy):
+
+                    # Create a sample
+                    args = dict(z=z, pos=pos, y=y.view(1, 1), dy=dy)
                     if mol_ids:
-                        data = Data(mol_id=mol_id, z=z, pos=pos, y=y.view(1, 1), dy=dy)
-                    else:
-                        data = Data(z=z, pos=pos, y=y.view(1, 1), dy=dy)
+                        args["mol_id"] = mol_id
+                    data = Data(**args)
 
                     if self.pre_filter is not None and not self.pre_filter(data):
                         continue

--- a/torchmdnet/datasets/qm9q.py
+++ b/torchmdnet/datasets/qm9q.py
@@ -120,12 +120,12 @@ class QM9q(Dataset):
 
         return energy * QM9q.HARTREE_TO_EV
 
-    def sample_iter(self):
+    def sample_iter(self, mol_ids=False):
 
         for path in tqdm(self.raw_paths, desc="Files"):
-            molecules = list(h5py.File(path).values())[0].values()
+            molecules = list(h5py.File(path).values())[0].items()
 
-            for mol in tqdm(molecules, desc="Molecules", leave=False):
+            for mol_id, mol in tqdm(molecules, desc="Molecules", leave=False):
                 z = pt.tensor(mol["atomic_numbers"], dtype=pt.long)
 
                 for conf in mol["energy"]:
@@ -171,7 +171,11 @@ class QM9q(Dataset):
                     if dy.norm(dim=1).max() > 100:  # eV/A
                         continue
 
-                    data = Data(z=z, pos=pos, y=y.view(1, 1), dy=dy, q=q, pq=pq, dp=dp)
+                    # Create a sample
+                    args = dict(z=z, pos=pos, y=y.view(1, 1), dy=dy, q=q, pq=pq, dp=dp)
+                    if mol_ids:
+                        args["mol_id"] = mol_id
+                    data = Data(**args)
 
                     if self.pre_filter is not None and not self.pre_filter(data):
                         continue


### PR DESCRIPTION
Optionally include the molecule ID to facilitate analysis

- [x] Implement `mol_id`:
   - [x] Ace
   - [x] ANI family
   - [x] COMP6 family
   - [x] QM9q
   - [x] SPICE