### PR TITLE
Access attribute instead of parameter

### DIFF
--- a/torchmdnet/datasets/md17.py
+++ b/torchmdnet/datasets/md17.py
@@ -36,7 +36,7 @@ class MD17(InMemoryDataset):
             molecules = ",".join(MD17.available_molecules)
         self.molecules = molecules.split(",")
 
-        for mol in molecules:
+        for mol in self.molecules:
             if mol not in MD17.available_molecules:
                 raise RuntimeError(f"Molecule '{mol}' does not exist in MD17")
 


### PR DESCRIPTION
We want to iterate through a list of molecule names here, not through the string name of the molecule. `self.molecules` is a list, `molecules` is a string.