### PR TITLE
Catch null dataset_arg

### DIFF
--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -28,8 +28,11 @@ class DataModule(LightningDataModule):
                     self.hparams["force_files"],
                 )
             else:
+                dataset_arg = {}
+                if self.hparams["dataset_arg"] is not None:
+                    dataset_arg = self.hparams["dataset_arg"]
                 self.dataset = getattr(datasets, self.hparams["dataset"])(
-                    self.hparams["dataset_root"], **self.hparams["dataset_arg"]
+                    self.hparams["dataset_root"], **dataset_arg
                 )
 
         self.idx_train, self.idx_val, self.idx_test = make_splits(


### PR DESCRIPTION
In the ANI1 example yaml file for example, `dataset_arg` is set to `null`, which causes an error while instantiating the dataset class. This adds a check and ignores the argument if it is `None`.