### PR TITLE
Don't store tensors in init args

### DIFF
--- a/tests/priors.yaml
+++ b/tests/priors.yaml
@@ -41,6 +41,9 @@ prior_model:
   - ZBL:
       cutoff_distance: 4.0
       max_num_neighbors: 50
+  - D2:
+      cutoff_distance: 10.0
+      max_num_neighbors: 100
   - Atomref
 rbf_type: expnorm
 redirect: false

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -5,7 +5,7 @@ import pytorch_lightning as pl
 from torchmdnet import models
 from torchmdnet.models.model import create_model, create_prior_models
 from torchmdnet.module import LNNP
-from torchmdnet.priors import Atomref, ZBL
+from torchmdnet.priors import Atomref, D2, ZBL
 from torch_scatter import scatter
 from utils import load_example_args, create_example_batch, DummyDataset
 from os.path import dirname, join
@@ -76,11 +76,14 @@ def test_multiple_priors():
 
     # Make sure the priors were created correctly.
 
-    assert len(priors) == 2
+    assert len(priors) == 3
     assert isinstance(priors[0], ZBL)
-    assert isinstance(priors[1], Atomref)
+    assert isinstance(priors[1], D2)
+    assert isinstance(priors[2], Atomref)
     assert priors[0].cutoff_distance == 4.0
     assert priors[0].max_num_neighbors == 50
+    assert priors[1].cutoff_distance == 10.0
+    assert priors[1].max_num_neighbors == 100
 
     # Save and load a checkpoint, and make sure the priors are correct.
 
@@ -89,8 +92,11 @@ def test_multiple_priors():
         f.seek(0)
         model2 = torch.load(f)
         priors2 = model2.model.prior_model
-        assert len(priors2) == 2
+        assert len(priors2) == 3
         assert isinstance(priors2[0], ZBL)
-        assert isinstance(priors2[1], Atomref)
+        assert isinstance(priors2[1], D2)
+        assert isinstance(priors2[2], Atomref)
         assert priors2[0].cutoff_distance == priors[0].cutoff_distance
         assert priors2[0].max_num_neighbors == priors[0].max_num_neighbors
+        assert priors2[1].cutoff_distance == priors[1].cutoff_distance
+        assert priors2[1].max_num_neighbors == priors[1].max_num_neighbors

--- a/torchmdnet/priors/d2.py
+++ b/torchmdnet/priors/d2.py
@@ -155,9 +155,9 @@ class D2(BasePrior):
         return {
             "cutoff_distance": self.cutoff_distance,
             "max_num_neighbors": self.max_num_neighbors,
-            "atomic_number": [int(i) for i in self.atomic_number.numpy()],
-            "distance_scale": float(self.distance_scale),
-            "energy_scale": float(self.energy_scale)
+            "atomic_number": self.atomic_number.tolist(),
+            "distance_scale": self.distance_scale.item(),
+            "energy_scale": self.energy_scale.item()
         }
 
     def post_reduce(self, y, z, pos, batch):

--- a/torchmdnet/priors/d2.py
+++ b/torchmdnet/priors/d2.py
@@ -155,9 +155,9 @@ class D2(BasePrior):
         return {
             "cutoff_distance": self.cutoff_distance,
             "max_num_neighbors": self.max_num_neighbors,
-            "atomic_number": self.atomic_number,
-            "distance_scale": self.distance_scale,
-            "energy_scale": self.energy_scale,
+            "atomic_number": [int(i) for i in self.atomic_number.numpy()],
+            "distance_scale": float(self.distance_scale),
+            "energy_scale": float(self.energy_scale)
         }
 
     def post_reduce(self, y, z, pos, batch):

--- a/torchmdnet/priors/d2.py
+++ b/torchmdnet/priors/d2.py
@@ -129,15 +129,10 @@ class D2(BasePrior):
             dataset.energy_scale if energy_scale is None else energy_scale
         )
 
-        # Convert to interal units: nm and J/mol
-        # NOTE: float32 is overflowed, if m and J are used
-        self.distance_scale *= 1e9  # m --> nm
-        self.energy_scale *= 6.02214076e23  # J --> J/mol
-
         # Distance calculator
         self.distances = Distance(
             cutoff_lower=0,
-            cutoff_upper=self.cutoff_distance / self.distance_scale,
+            cutoff_upper=self.cutoff_distance,
             max_num_neighbors=self.max_num_neighbors,
         )
 
@@ -155,15 +150,21 @@ class D2(BasePrior):
         return {
             "cutoff_distance": self.cutoff_distance,
             "max_num_neighbors": self.max_num_neighbors,
-            "atomic_number": self.atomic_number.tolist(),
-            "distance_scale": self.distance_scale.item(),
-            "energy_scale": self.energy_scale.item()
+            "atomic_number": self.atomic_number,
+            "distance_scale": self.distance_scale,
+            "energy_scale": self.energy_scale
         }
 
     def post_reduce(self, y, z, pos, batch, extra_args):
 
+        # Convert to interal units: nm and J/mol
+        # NOTE: float32 is overflowed, if m and J are used
+        distance_scale = self.distance_scale*1e9  # m --> nm
+        energy_scale = self.energy_scale*6.02214076e23  # J --> J/mol
+
         # Get atom pairs and their distancence
-        ij, R_ij, _ = self.distances(pos * self.distance_scale, batch)
+        ij, R_ij, _ = self.distances(pos, batch)
+        R_ij *= distance_scale
 
         # No interactions
         if ij.shape[1] == 0:
@@ -184,4 +185,4 @@ class D2(BasePrior):
         E_disp /= 2  # The pairs appear twice
         E_disp = E_disp.reshape(y.shape)
 
-        return y + E_disp / self.energy_scale
+        return y + E_disp / energy_scale

--- a/torchmdnet/priors/zbl.py
+++ b/torchmdnet/priors/zbl.py
@@ -1,5 +1,6 @@
 import torch
 from torchmdnet.priors.base import BasePrior
+from torchmdnet.priors.d2 import D2
 from torchmdnet.models.utils import Distance, CosineCutoff
 
 class ZBL(BasePrior):
@@ -22,7 +23,7 @@ class ZBL(BasePrior):
             distance_scale = dataset.distance_scale
         if energy_scale is None:
             energy_scale = dataset.energy_scale
-        atomic_number = torch.as_tensor(atomic_number, dtype=torch.int8)
+        atomic_number = torch.as_tensor(atomic_number, dtype=torch.long)
         self.register_buffer("atomic_number", atomic_number)
         self.distance = Distance(0, cutoff_distance, max_num_neighbors=max_num_neighbors)
         self.cutoff = CosineCutoff(cutoff_upper=cutoff_distance)
@@ -34,9 +35,9 @@ class ZBL(BasePrior):
     def get_init_args(self):
         return {'cutoff_distance': self.cutoff_distance,
                 'max_num_neighbors': self.max_num_neighbors,
-                'atomic_number': self.atomic_number,
-                'distance_scale': self.distance_scale,
-                'energy_scale': self.energy_scale}
+                'atomic_number': [int(i) for i in self.atomic_number.numpy()],
+                'distance_scale': float(self.distance_scale),
+                'energy_scale': float(self.energy_scale)}
 
     def reset_parameters(self):
         pass

--- a/torchmdnet/priors/zbl.py
+++ b/torchmdnet/priors/zbl.py
@@ -34,9 +34,9 @@ class ZBL(BasePrior):
     def get_init_args(self):
         return {'cutoff_distance': self.cutoff_distance,
                 'max_num_neighbors': self.max_num_neighbors,
-                'atomic_number': [int(i) for i in self.atomic_number.numpy()],
-                'distance_scale': float(self.distance_scale),
-                'energy_scale': float(self.energy_scale)}
+                'atomic_number': self.atomic_number.tolist(),
+                'distance_scale': self.distance_scale.item(),
+                'energy_scale': self.energy_scale.item()}
 
     def reset_parameters(self):
         pass

--- a/torchmdnet/priors/zbl.py
+++ b/torchmdnet/priors/zbl.py
@@ -35,8 +35,8 @@ class ZBL(BasePrior):
         return {'cutoff_distance': self.cutoff_distance,
                 'max_num_neighbors': self.max_num_neighbors,
                 'atomic_number': self.atomic_number.tolist(),
-                'distance_scale': self.distance_scale.item(),
-                'energy_scale': self.energy_scale.item()}
+                'distance_scale': self.distance_scale,
+                'energy_scale': self.energy_scale}
 
     def reset_parameters(self):
         pass

--- a/torchmdnet/priors/zbl.py
+++ b/torchmdnet/priors/zbl.py
@@ -1,6 +1,5 @@
 import torch
 from torchmdnet.priors.base import BasePrior
-from torchmdnet.priors.d2 import D2
 from torchmdnet.models.utils import Distance, CosineCutoff
 
 class ZBL(BasePrior):


### PR DESCRIPTION
On some computers (but not others) this leads to an error when resuming training, due to tensors stored in `hparams.yaml`.  I'm not sure why it only happens on some computers.