### PR TITLE
Allow datasets to pass extra fields to models

### DIFF
--- a/tests/test_prior_d2.py
+++ b/tests/test_prior_d2.py
@@ -80,6 +80,6 @@ def test_d2(test_case):
     batch = pt.tensor(data["batch"])
 
     y_init = pt.zeros_like(y_ref)
-    y_res = prior.post_reduce(y_init, z, pos, batch)
+    y_res = prior.post_reduce(y_init, z, pos, batch, {})
 
     pt.testing.assert_allclose(y_res, y_ref)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -45,7 +45,7 @@ def test_zbl():
     # Use the ZBL class to compute the energy.
 
     zbl = ZBL(10.0, 5, atomic_number, distance_scale=distance_scale, energy_scale=energy_scale)
-    energy = zbl.post_reduce(torch.zeros((1,)), types, pos, torch.zeros_like(types))[0]
+    energy = zbl.post_reduce(torch.zeros((1,)), types, pos, torch.zeros_like(types), {})[0]
 
     # Compare to the expected value.
 

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -1,5 +1,5 @@
 import re
-from typing import Optional, List, Tuple
+from typing import Optional, List, Tuple, Dict
 import torch
 from torch.autograd import grad
 from torch import nn, Tensor
@@ -196,6 +196,7 @@ class TorchMD_Net(nn.Module):
         batch: Optional[Tensor] = None,
         q: Optional[Tensor] = None,
         s: Optional[Tensor] = None,
+        extra_args: Optional[Dict[str, Tensor]] = None
     ) -> Tuple[Tensor, Optional[Tensor]]:
 
         assert z.dim() == 1 and z.dtype == torch.long
@@ -217,7 +218,7 @@ class TorchMD_Net(nn.Module):
         # apply atom-wise prior model
         if self.prior_model is not None:
             for prior in self.prior_model:
-                x = prior.pre_reduce(x, z, pos, batch)
+                x = prior.pre_reduce(x, z, pos, batch, extra_args)
 
         # aggregate atoms
         x = self.output_model.reduce(x, batch)
@@ -232,7 +233,7 @@ class TorchMD_Net(nn.Module):
         # apply molecular-wise prior model
         if self.prior_model is not None:
             for prior in self.prior_model:
-                y = prior.post_reduce(y, z, pos, batch)
+                y = prior.post_reduce(y, z, pos, batch, extra_args)
 
         # compute gradients with respect to coordinates
         if self.derivative:

--- a/torchmdnet/priors/atomref.py
+++ b/torchmdnet/priors/atomref.py
@@ -37,5 +37,5 @@ class Atomref(BasePrior):
     def get_init_args(self):
         return dict(max_z=self.initial_atomref.size(0))
 
-    def pre_reduce(self, x, z, pos, batch):
+    def pre_reduce(self, x, z, pos, batch, extra_args):
         return x + self.atomref(z)

--- a/torchmdnet/priors/base.py
+++ b/torchmdnet/priors/base.py
@@ -18,7 +18,7 @@ class BasePrior(nn.Module):
         """
         return {}
 
-    def pre_reduce(self, x, z, pos, batch):
+    def pre_reduce(self, x, z, pos, batch, extra_args):
         r"""Pre-reduce method of the prior model.
 
         Args:
@@ -26,13 +26,14 @@ class BasePrior(nn.Module):
             z (torch.Tensor): atom types of all atoms.
             pos (torch.Tensor): 3D atomic coordinates.
             batch (torch.Tensor): tensor containing the sample index for each atom.
+            extra_args (dict): any addition fields provided by the dataset
 
         Returns:
             torch.Tensor: updated scalar atom-wise predictions
         """
         return x
 
-    def post_reduce(self, y, z, pos, batch):
+    def post_reduce(self, y, z, pos, batch, extra_args):
         r"""Post-reduce method of the prior model.
 
         Args:
@@ -40,6 +41,7 @@ class BasePrior(nn.Module):
             z (torch.Tensor): atom types of all atoms.
             pos (torch.Tensor): 3D atomic coordinates.
             batch (torch.Tensor): tensor containing the sample index for each atom.
+            extra_args (dict): any addition fields provided by the dataset
 
         Returns:
             torch.Tensor: updated scalar molecular-wise predictions

--- a/torchmdnet/priors/d2.py
+++ b/torchmdnet/priors/d2.py
@@ -160,7 +160,7 @@ class D2(BasePrior):
             "energy_scale": self.energy_scale,
         }
 
-    def post_reduce(self, y, z, pos, batch):
+    def post_reduce(self, y, z, pos, batch, extra_args):
 
         # Get atom pairs and their distancence
         ij, R_ij, _ = self.distances(pos * self.distance_scale, batch)

--- a/torchmdnet/priors/zbl.py
+++ b/torchmdnet/priors/zbl.py
@@ -41,7 +41,7 @@ class ZBL(BasePrior):
     def reset_parameters(self):
         pass
 
-    def post_reduce(self, y, z, pos, batch):
+    def post_reduce(self, y, z, pos, batch, extra_args):
         edge_index, distance, _ = self.distance(pos, batch)
         atomic_number = self.atomic_number[z[edge_index]]
         # 5.29e-11 is the Bohr radius in meters.  All other numbers are magic constants from the ZBL potential.


### PR DESCRIPTION
This implements the feature described in https://github.com/torchmd/torchmd-net/issues/26#issuecomment-1334583040.  The dataset can store arbitrary extra fields in the Data objects it returns.  They get passed to the model in the `extra_args` parameter.  At the moment, the model only passes them on to the priors, since that's the initial thing I need them for.  It would be just as easy to pass them to the representation model and output model, if we find we need that in the future.

As an example of using this, I made the HDF5 dataset class support an optional `partial_charges` field.

We might consider getting rid of the hardcoded `q` and `s` arguments (I couldn't find any existing models that use them) and letting them get passed in `extra_args` if they're ever needed.