### PR TITLE
Fix deprecated usage of np.int with numpy>1.23

### DIFF
--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -54,7 +54,7 @@ class Custom(Dataset):
         nfiles = len(self.coordfiles)
         for i in range(nfiles):
             coord_data = np.load(self.coordfiles[i])
-            embed_data = np.load(self.embedfiles[i]).astype(np.int)
+            embed_data = np.load(self.embedfiles[i]).astype(int)
             size = coord_data.shape[0]
             self.index.extend(list(zip([i] * size, range(size))))
 
@@ -81,7 +81,7 @@ class Custom(Dataset):
         fileid, index = self.index[idx]
 
         coord_data = np.array(np.load(self.coordfiles[fileid], mmap_mode="r")[index])
-        embed_data = np.load(self.embedfiles[fileid]).astype(np.int)
+        embed_data = np.load(self.embedfiles[fileid]).astype(int)
 
         features = dict(
             pos=torch.from_numpy(coord_data), z=torch.from_numpy(embed_data)

--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -93,7 +93,7 @@ def train_val_test_split(dset_len, train_size, val_size, test_size, seed, order=
     if total < dset_len:
         rank_zero_warn(f"{dset_len - total} samples were excluded from the dataset")
 
-    idxs = np.arange(dset_len, dtype=np.int)
+    idxs = np.arange(dset_len, dtype=int)
     if order is None:
         idxs = np.random.default_rng(seed).permutation(idxs)
 


### PR DESCRIPTION
Tests failed for me (with the suggested environment.yml, which installed numpy=1.24) due to usage of the [deprecated numpy.int](https://numpy.org/devdocs/release/1.20.0-notes.html#using-the-aliases-of-builtin-types-like-np-int-is-deprecated).
I replaced a couple of instances of np.int by just int, as suggested in the numpy docs.

All tests pass with the numpy 1.24.