### PR TITLE
Update SPICE

### DIFF
--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -13,9 +13,9 @@ class SPICE(Dataset):
     SPICE dataset (https://github.com/openmm/spice-dataset)
 
     The dataset has several versions (https://github.com/openmm/spice-dataset/releases).
-    The version can be selected with `version`. By default, verions 1.0 is loaded.
+    The version can be selected with `version`. By default, version 1.1.3 is loaded.
 
-    >>> ds = SPICE(".", version="1.1")
+    >>> ds = SPICE(".", version="1.1.3")
 
     The dataset consists of several subsets (https://github.com/openmm/spice-dataset/blob/main/downloader/config.yaml).
     The subsets can be selected with `subsets`. By default, all the subsets are loaded.
@@ -75,7 +75,7 @@ class SPICE(Dataset):
         transform=None,
         pre_transform=None,
         pre_filter=None,
-        version="1.1.1",
+        version="1.1.3",
         subsets=None,
         max_gradient=None,
         subsample_molecules=1,

--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -39,17 +39,25 @@ class SPICE(Dataset):
     HARTREE_TO_EV = 27.211386246
     BORH_TO_ANGSTROM = 0.529177
 
+    VERSIONS = {
+        "1.0": {"url": "https://github.com/openmm/spice-dataset/releases/download/1.0", "file": "SPICE.hdf5"},
+        "1.1": {"url": "https://github.com/openmm/spice-dataset/releases/download/1.1", "file": "SPICE.hdf5"},
+        "1.1.1": {"url": "https://zenodo.org/record/7258940/files", "file": "SPICE-1.1.1.hdf5"},
+        "1.1.2": {"url": "https://zenodo.org/record/7338495/files", "file": "SPICE-1.1.2.hdf5"},
+        "1.1.3": {"url": "https://zenodo.org/record/7606550/files", "file": "SPICE-1.1.3.hdf5"},
+    }
+
     @property
     def raw_dir(self):
         return os.path.join(super().raw_dir, self.version)
 
     @property
     def raw_file_names(self):
-        return "SPICE.hdf5"
+        return self.VERSIONS[self.version]["file"]
 
     @property
     def raw_url(self):
-        return f"https://github.com/openmm/spice-dataset/releases/download/{self.version}/{self.raw_file_names}"
+        return f"{self.VERSIONS[self.version]['url']}/{self.VERSIONS[self.version]['file']}"
 
     @property
     def processed_file_names(self):
@@ -75,7 +83,8 @@ class SPICE(Dataset):
         arg_hash = f"{version}{subsets}{max_gradient}{subsample_molecules}"
         arg_hash = hashlib.md5(arg_hash.encode()).hexdigest()
         self.name = f"{self.__class__.__name__}-{arg_hash}"
-        self.version = version
+        self.version = str(version)
+        assert self.version in self.VERSIONS
         self.subsets = subsets
         self.max_gradient = max_gradient
         self.subsample_molecules = int(subsample_molecules)


### PR DESCRIPTION
The SPICE dataset is now published on Zendo (https://zenodo.org/record/7606550)

- [x] Download the old versions from GitHub
- [x] Download the new versions from Zendo
- [x] Set default version to `1.1.3`