### PR TITLE
New calculator

### DIFF
--- a/torchmdnet/calculators.py
+++ b/torchmdnet/calculators.py
@@ -3,15 +3,15 @@ from torchmdnet.models.model import load_model
 
 # dict of preset transforms
 tranforms = {
-    "eV/A": lambda energy, forces: (
+    "eV/A -> kcal/mol/A": lambda energy, forces: (
         energy * 23.0609,
         forces * 23.0609,
     ),  # eV->kcal/mol, eV/A -> kcal/mol/A
-    "Hartree/Bohr": lambda energy, forces: (
+    "Hartree/Bohr -> kcal/mol/A": lambda energy, forces: (
         energy * 627.509,
         forces * 627.509 / 0.529177,
     ),  # Hartree -> kcal/mol, Hartree/Bohr -> kcal/mol/A
-    "Haetree/A": lambda energy, forces: (
+    "Haetree/A -> kcal/mol/A": lambda energy, forces: (
         energy * 627.509,
         forces * 627.509,
     ),  # Hartree -> kcal/mol, Hartree/A -> kcal/mol/A


### PR DESCRIPTION
This is the new calculator of torchmd-net. The idea is to have a way to transform the units of measure of energy and forces to run a molecular dynamic simulation with torchmd that works only with forces in kcal/mol/A. 
- [x] update calculator in torchmd-net
- [ ] add the new argument `output_transform`  in torchmd/run.py when the external module is built. 

Example of yaml file to run the simulation with torchmd using the `output_transform `:
```python 
external:
  module: torchmdnet.calculators
  file: [path to the NNP ckpt]
  output_transform: 'lambda energy, forces: (energy * 23.0609, forces * 23.0609)' # eV->kcal/mol, eV/A->kcal/mol/A
```

