### PR TITLE
Adding a cell list neighbor list module

### DIFF
--- a/benchmarks/neighbors.py
+++ b/benchmarks/neighbors.py
@@ -1,7 +1,7 @@
 import os
 import torch
 import numpy as np
-from torchmdnet.models.utils import Distance, DistanceCellList
+from torchmdnet.models.utils import Distance, OptimizedDistance
 
 
 def benchmark_neighbors(
@@ -58,7 +58,7 @@ def benchmark_neighbors(
     if strategy != "distance":
         max_num_pairs = (expected_num_neighbors * n_atoms_per_batch.sum()).item() * 2
         box = torch.eye(3, device=device) * lbox
-        nl = DistanceCellList(
+        nl = OptimizedDistance(
             cutoff_upper=cutoff,
             max_num_pairs=max_num_pairs,
             strategy=strategy,

--- a/benchmarks/neighbors.py
+++ b/benchmarks/neighbors.py
@@ -210,27 +210,3 @@ if __name__ == "__main__":
                     results["distance", n_particles],
                 )
             )
-
-    # # Print a second table showing time per atom, show in ns
-    # print("\n")
-    # print("Time per atom")
-    # print(
-    #     "{:<10} {:<10} {:<10} {:<10} {:<10}".format(
-    #         "Batch size", "Shared(ns)", "Brute(ns)", "Cell(ns)", "Distance(ns)"
-    #     )
-    # )
-    # print(
-    #     "{:<10} {:<10} {:<10} {:<10} {:<10}".format(
-    #         "----------", "---------", "---------", "---------", "---------"
-    #     )
-    # )
-    # for n_batches in batch_sizes:
-    #     print(
-    #         "{:<10} {:<10.2f} {:<10.2f} {:<10.2f} {:<10.2f}".format(
-    #             n_batches,
-    #             results["shared", n_batches] / n_particles * 1e6,
-    #             results["brute", n_batches] / n_particles * 1e6,
-    #             results["cell", n_batches] / n_particles * 1e6,
-    #             results["distance", n_batches] / n_particles * 1e6,
-    #         )
-    #     )

--- a/benchmarks/neighbors.py
+++ b/benchmarks/neighbors.py
@@ -4,10 +4,9 @@ import numpy as np
 from torchmdnet.models.utils import Distance, DistanceCellList
 
 
-
-
-
-def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_num_neighbors, density):
+def benchmark_neighbors(
+    device, strategy, n_batches, total_num_particles, mean_num_neighbors, density
+):
     """Benchmark the neighbor list generation.
 
     Parameters
@@ -33,9 +32,11 @@ def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_n
     np.random.seed(43211)
     num_particles = total_num_particles // n_batches
     expected_num_neighbors = mean_num_neighbors
-    cutoff = np.cbrt(3 * expected_num_neighbors / (4 * np.pi * density));
-    n_atoms_per_batch = torch.randint(int(num_particles/2), int(num_particles*2), size=(n_batches,),device="cpu")
-    #Fix so that the total number of particles is correct. Special care if the difference is negative
+    cutoff = np.cbrt(3 * expected_num_neighbors / (4 * np.pi * density))
+    n_atoms_per_batch = torch.randint(
+        int(num_particles / 2), int(num_particles * 2), size=(n_batches,), device="cpu"
+    )
+    # Fix so that the total number of particles is correct. Special care if the difference is negative
     difference = total_num_particles - n_atoms_per_batch.sum()
     if difference > 0:
         while difference > 0:
@@ -49,30 +50,45 @@ def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_n
             if n_atoms_per_batch[i] > num_particles:
                 n_atoms_per_batch[i] -= 1
                 difference += 1
-    lbox = np.cbrt(num_particles / density);
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
-    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
-    pos = torch.rand(cumsum[-1], 3, device="cpu").to(device)*lbox
-    if strategy != 'distance':
-        max_num_pairs = (expected_num_neighbors * n_atoms_per_batch.sum()).item()*2
-        box = torch.eye(3, device=device)*lbox
-        nl = DistanceCellList(cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, loop=False, include_transpose=True, resize_to_fit=False)
+    lbox = np.cbrt(num_particles / density)
+    batch = torch.repeat_interleave(
+        torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch
+    ).to(device)
+    cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
+    pos = torch.rand(cumsum[-1], 3, device="cpu").to(device) * lbox
+    if strategy != "distance":
+        max_num_pairs = (expected_num_neighbors * n_atoms_per_batch.sum()).item() * 2
+        box = torch.eye(3, device=device) * lbox
+        nl = DistanceCellList(
+            cutoff_upper=cutoff,
+            max_num_pairs=max_num_pairs,
+            strategy=strategy,
+            box=box,
+            loop=False,
+            include_transpose=True,
+            resize_to_fit=False,
+        )
     else:
-        max_num_neighbors = int(expected_num_neighbors*5)
-        nl = Distance(loop=False, cutoff_lower=0.0, cutoff_upper=cutoff, max_num_neighbors=max_num_neighbors)
-    #Warmup
+        max_num_neighbors = int(expected_num_neighbors * 5)
+        nl = Distance(
+            loop=False,
+            cutoff_lower=0.0,
+            cutoff_upper=cutoff,
+            max_num_neighbors=max_num_neighbors,
+        )
+    # Warmup
     for i in range(10):
         neighbors, distances, distance_vecs = nl(pos, batch)
-    if device == 'cuda':
+    if device == "cuda":
         torch.cuda.synchronize()
     nruns = 50
-    if device == 'cuda':
+    if device == "cuda":
         torch.cuda.synchronize()
 
     start = torch.cuda.Event(enable_timing=True)
     end = torch.cuda.Event(enable_timing=True)
-    #record in a cuda graph
-    if strategy != 'distance':
+    # record in a cuda graph
+    if strategy != "distance":
         graph = torch.cuda.CUDAGraph()
         with torch.cuda.graph(graph):
             neighbors, distances, distance_vecs = nl(pos, batch)
@@ -85,59 +101,89 @@ def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_n
         for i in range(nruns):
             neighbors, distances, distance_vecs = nl(pos, batch)
         end.record()
-    if device == 'cuda':
+    if device == "cuda":
         torch.cuda.synchronize()
-    #Final time
-    return (start.elapsed_time(end) / nruns)
+    # Final time
+    return start.elapsed_time(end) / nruns
 
-if __name__ == '__main__':
+
+if __name__ == "__main__":
     n_particles = 32767
-    mean_num_neighbors = min(n_particles, 64);
-    density=0.5
-    print("Benchmarking neighbor list generation for {} particles with {} neighbors on average".format(n_particles, mean_num_neighbors))
+    mean_num_neighbors = min(n_particles, 64)
+    density = 0.5
+    print(
+        "Benchmarking neighbor list generation for {} particles with {} neighbors on average".format(
+            n_particles, mean_num_neighbors
+        )
+    )
     results = {}
     batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
-    for strategy in ['shared', 'brute', 'cell', 'distance']:
+    for strategy in ["shared", "brute", "cell", "distance"]:
         # print("Strategy: {}".format(strategy))
         # print("--------")
         # print("{:<10} {:<10}".format("Batch size", "Time (ms)"))
         # print("{:<10} {:<10}".format("----------", "---------"))
-        #Loop over different number of batches, random
+        # Loop over different number of batches, random
         for n_batches in batch_sizes:
-            time = benchmark_neighbors(device='cuda',
-                                       strategy=strategy,
-                                       n_batches=n_batches,
-                                       total_num_particles=n_particles,
-                                       mean_num_neighbors=mean_num_neighbors,
-                                       density=density
-                                       )
-            #Store results in a dictionary
+            time = benchmark_neighbors(
+                device="cuda",
+                strategy=strategy,
+                n_batches=n_batches,
+                total_num_particles=n_particles,
+                mean_num_neighbors=mean_num_neighbors,
+                density=density,
+            )
+            # Store results in a dictionary
             results[strategy, n_batches] = time
-            #print("{:<10} {:<10.2f}".format(n_batches, time))
+            # print("{:<10} {:<10.2f}".format(n_batches, time))
     print("Summary")
     print("-------")
-    print("{:<10} {:<21} {:<21} {:<18} {:<10}".format("Batch size", "Shared(ms)", "Brute(ms)", "Cell(ms)", "Distance(ms)"))
-    print("{:<10} {:<21} {:<21} {:<18} {:<10}".format("----------", "---------", "---------", "---------", "---------"))
-    #Print a column per strategy, show speedup over Distance in parenthesis
+    print(
+        "{:<10} {:<21} {:<21} {:<18} {:<10}".format(
+            "Batch size", "Shared(ms)", "Brute(ms)", "Cell(ms)", "Distance(ms)"
+        )
+    )
+    print(
+        "{:<10} {:<21} {:<21} {:<18} {:<10}".format(
+            "----------", "---------", "---------", "---------", "---------"
+        )
+    )
+    # Print a column per strategy, show speedup over Distance in parenthesis
     for n_batches in batch_sizes:
-        base = results['distance', n_batches]
-        print("{:<10} {:<4.2f} x{:<14.2f} {:<4.2f} x{:<14.2f}  {:<4.2f} x{:<14.2f} {:<10.2f}".format(n_batches,
-                                                                                    results['shared', n_batches],
-                                                                                    base/results['shared', n_batches],
-                                                                                  results['brute', n_batches],
-                                                                                  base/results['brute', n_batches],
-                                                                                  results['cell', n_batches],
-                                                                                  base/results['cell', n_batches],
-                                                                                  results['distance', n_batches]))
+        base = results["distance", n_batches]
+        print(
+            "{:<10} {:<4.2f} x{:<14.2f} {:<4.2f} x{:<14.2f}  {:<4.2f} x{:<14.2f} {:<10.2f}".format(
+                n_batches,
+                results["shared", n_batches],
+                base / results["shared", n_batches],
+                results["brute", n_batches],
+                base / results["brute", n_batches],
+                results["cell", n_batches],
+                base / results["cell", n_batches],
+                results["distance", n_batches],
+            )
+        )
 
-    #Print a second table showing time per atom, show in ns
+    # Print a second table showing time per atom, show in ns
     print("\n")
     print("Time per atom")
-    print("{:<10} {:<10} {:<10} {:<10} {:<10}".format("Batch size", "Shared(ns)", "Brute(ns)", "Cell(ns)", "Distance(ns)"))
-    print("{:<10} {:<10} {:<10} {:<10} {:<10}".format("----------", "---------", "---------", "---------", "---------"))
+    print(
+        "{:<10} {:<10} {:<10} {:<10} {:<10}".format(
+            "Batch size", "Shared(ns)", "Brute(ns)", "Cell(ns)", "Distance(ns)"
+        )
+    )
+    print(
+        "{:<10} {:<10} {:<10} {:<10} {:<10}".format(
+            "----------", "---------", "---------", "---------", "---------"
+        )
+    )
     for n_batches in batch_sizes:
-        print("{:<10} {:<10.2f} {:<10.2f} {:<10.2f} {:<10.2f}".format(n_batches,
-                                                            results['shared', n_batches]/n_particles*1e6,
-                                                            results['brute', n_batches]/n_particles*1e6,
-                                                            results['cell', n_batches]/n_particles*1e6,
-                                                            results['distance', n_batches]/n_particles*1e6))
+        print(
+            "{:<10} {:<10.2f} {:<10.2f} {:<10.2f} {:<10.2f}".format(
+                n_batches,
+                results["shared", n_batches] / n_particles * 1e6,
+                results["brute", n_batches] / n_particles * 1e6,
+                results["cell", n_batches] / n_particles * 1e6,
+                results["distance", n_batches] / n_particles * 1e6,
+            )
+        )

--- a/benchmarks/neighbors.py
+++ b/benchmarks/neighbors.py
@@ -6,7 +6,8 @@ from torchmdnet.models.utils import Distance, DistanceCellList
 
 
 
-def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_num_neighbors=32):
+
+def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_num_neighbors, density):
     """Benchmark the neighbor list generation.
 
     Parameters
@@ -19,13 +20,17 @@ def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_n
         Number of batches to generate.
     total_num_particles : int
         Total number of particles.
+    mean_num_neighbors : int
+        Mean number of neighbors per particle.
+    density : float
+        Density of the system.
     Returns
     -------
     float
         Average time per batch in seconds.
     """
-    density = 0.7;
     torch.random.manual_seed(12344)
+    np.random.seed(43211)
     num_particles = total_num_particles // n_batches
     expected_num_neighbors = mean_num_neighbors
     cutoff = np.cbrt(3 * expected_num_neighbors / (4 * np.pi * density));
@@ -51,21 +56,16 @@ def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_n
     if strategy != 'distance':
         max_num_pairs = (expected_num_neighbors * n_atoms_per_batch.sum()).item()*2
         box = torch.eye(3, device=device)*lbox
-        nl = DistanceCellList(cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box)
+        nl = DistanceCellList(cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, loop=False, include_transpose=True, resize_to_fit=False)
     else:
         max_num_neighbors = int(expected_num_neighbors*5)
         nl = Distance(loop=False, cutoff_lower=0.0, cutoff_upper=cutoff, max_num_neighbors=max_num_neighbors)
     #Warmup
     for i in range(10):
         neighbors, distances, distance_vecs = nl(pos, batch)
-    #print
-    print("Batch with largest number of atoms: {}".format(int(n_atoms_per_batch.max())))
-    print("Batch with smallest number of atoms: {}".format(int(n_atoms_per_batch.min())))
-    print("Number of pairs: {}, Number of particles: {}".format(int(neighbors.shape[1]), int(n_atoms_per_batch.to(torch.double).
-                                                                                             sum().item())))
     if device == 'cuda':
         torch.cuda.synchronize()
-    nruns = 10
+    nruns = 50
     if device == 'cuda':
         torch.cuda.synchronize()
 
@@ -83,35 +83,38 @@ def benchmark_neighbors(device, strategy, n_batches, total_num_particles, mean_n
 
 if __name__ == '__main__':
     n_particles = 32767
-    mean_num_neighbors = min(n_particles, 16);
+    mean_num_neighbors = min(n_particles, 64);
+    density=0.5
     print("Benchmarking neighbor list generation for {} particles with {} neighbors on average".format(n_particles, mean_num_neighbors))
     results = {}
-    batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512]
-    for strategy in ['brute', 'cell', 'distance']:
-        print("Strategy: {}".format(strategy))
-        print("--------")
-        print("{:<10} {:<10}".format("Batch size", "Time (ms)"))
-        print("{:<10} {:<10}".format("----------", "---------"))
+    batch_sizes = [1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024]
+    for strategy in ['shared', 'brute', 'cell', 'distance']:
+        # print("Strategy: {}".format(strategy))
+        # print("--------")
+        # print("{:<10} {:<10}".format("Batch size", "Time (ms)"))
+        # print("{:<10} {:<10}".format("----------", "---------"))
         #Loop over different number of batches, random
         for n_batches in batch_sizes:
             time = benchmark_neighbors(device='cuda',
                                        strategy=strategy,
                                        n_batches=n_batches,
                                        total_num_particles=n_particles,
-                                       mean_num_neighbors=mean_num_neighbors
+                                       mean_num_neighbors=mean_num_neighbors,
+                                       density=density
                                        )
             #Store results in a dictionary
             results[strategy, n_batches] = time
-            print("{:<10} {:<10.2f}".format(n_batches, time))
-        print("\n")
+            #print("{:<10} {:<10.2f}".format(n_batches, time))
     print("Summary")
     print("-------")
-    print("{:<10} {:<21} {:<18} {:<10}".format("Batch size", "Brute(ms)", "Cell(ms)", "Distance(ms)"))
-    print("{:<10} {:<21} {:<18} {:<10}".format("----------", "---------", "--------", "-----------"))
+    print("{:<10} {:<21} {:<21} {:<18} {:<10}".format("Batch size", "Shared(ms)", "Brute(ms)", "Cell(ms)", "Distance(ms)"))
+    print("{:<10} {:<21} {:<21} {:<18} {:<10}".format("----------", "---------", "---------", "---------", "---------"))
     #Print a column per strategy, show speedup over Distance in parenthesis
     for n_batches in batch_sizes:
         base = results['distance', n_batches]
-        print("{:<10} {:<4.2f} x{:<14.2f}  {:<4.2f} x{:<14.2f} {:<10.2f}".format(n_batches,
+        print("{:<10} {:<4.2f} x{:<14.2f} {:<4.2f} x{:<14.2f}  {:<4.2f} x{:<14.2f} {:<10.2f}".format(n_batches,
+                                                                                    results['shared', n_batches],
+                                                                                    base/results['shared', n_batches],
                                                                                   results['brute', n_batches],
                                                                                   base/results['brute', n_batches],
                                                                                   results['cell', n_batches],
@@ -121,10 +124,11 @@ if __name__ == '__main__':
     #Print a second table showing time per atom, show in ns
     print("\n")
     print("Time per atom")
-    print("{:<10} {:<10} {:<10} {:<10}".format("Batch size", "Brute(ns)", "Cell(ns)", "Distance(ns)"))
-    print("{:<10} {:<10} {:<10} {:<10}".format("----------", "---------", "--------", "-----------"))
+    print("{:<10} {:<10} {:<10} {:<10} {:<10}".format("Batch size", "Shared(ns)", "Brute(ns)", "Cell(ns)", "Distance(ns)"))
+    print("{:<10} {:<10} {:<10} {:<10} {:<10}".format("----------", "---------", "---------", "---------", "---------"))
     for n_batches in batch_sizes:
-        print("{:<10} {:<10.2f} {:<10.2f} {:<10.2f}".format(n_batches,
+        print("{:<10} {:<10.2f} {:<10.2f} {:<10.2f} {:<10.2f}".format(n_batches,
+                                                            results['shared', n_batches]/n_particles*1e6,
                                                             results['brute', n_batches]/n_particles*1e6,
                                                             results['cell', n_batches]/n_particles*1e6,
                                                             results['distance', n_batches]/n_particles*1e6))

--- a/benchmarks/neighbors.py
+++ b/benchmarks/neighbors.py
@@ -110,7 +110,7 @@ def benchmark_neighbors(
 if __name__ == "__main__":
     n_particles = 32767
     mean_num_neighbors = min(n_particles, 64)
-    density = 0.5
+    density = 0.8
     print(
         "Benchmarking neighbor list generation for {} particles with {} neighbors on average".format(
             n_particles, mean_num_neighbors

--- a/environment.yml
+++ b/environment.yml
@@ -18,3 +18,4 @@ dependencies:
   - flake8
   - pytest
   - psutil
+  - ninja

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name="torchmd-net",
     version=version,
     packages=find_packages(),
-    package_data={"torchmdnet": ["neighbors/neighbors*"]},
+    package_data={"torchmdnet": ["neighbors/neighbors*", "neighbors/common.cuh"]},
     include_package_data=True,
     entry_points={"console_scripts": ["torchmd-train = torchmdnet.scripts.train:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
     name="torchmd-net",
     version=version,
     packages=find_packages(),
-    package_data={"torchmdnet": ["neighbors/neighbors*", "neighbors/common.cuh"]},
+    package_data={"torchmdnet": ["neighbors/neighbors*", "neighbors/*.cu*"]},
     include_package_data=True,
     entry_points={"console_scripts": ["torchmd-train = torchmdnet.scripts.train:main"]},
 )

--- a/setup.py
+++ b/setup.py
@@ -15,5 +15,7 @@ setup(
     name="torchmd-net",
     version=version,
     packages=find_packages(),
+    package_data={"torchmdnet": ["neighbors/neighbors*"]},
+    include_package_data=True,
     entry_points={"console_scripts": ["torchmd-train = torchmdnet.scripts.train:main"]},
 )

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -304,3 +304,66 @@ def test_jit_script_compatible(device, strategy, n_batches, cutoff, loop, includ
     assert np.allclose(neighbors, ref_neighbors)
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
+
+
+
+
+@pytest.mark.parametrize("device", ["cuda"])
+@pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
+@pytest.mark.parametrize("n_batches", [1, 128])
+@pytest.mark.parametrize("cutoff", [1.0])
+@pytest.mark.parametrize("loop", [True, False])
+@pytest.mark.parametrize("include_transpose", [True, False])
+@pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
+@pytest.mark.parametrize('dtype', [torch.float32])
+def test_cuda_graph_compatible(device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    if box_type == "triclinic" and strategy == "cell":
+        pytest.skip("Triclinic only supported for brute force")
+    torch.manual_seed(4321)
+    n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
+    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
+    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
+    lbox=10.0
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype)*lbox
+    #Ensure there is at least one pair
+    pos[0,:] = torch.zeros(3)
+    pos[1,:] = torch.zeros(3)
+    pos.requires_grad = True
+    if(box_type is None):
+        box = None
+    else:
+        box = torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(pos.dtype).to(device)
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box)
+    max_num_pairs = ref_neighbors.shape[1]
+    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=include_transpose, check_errors=False, resize_to_fit=False)
+    batch.to(device)
+
+
+    graph = torch.cuda.CUDAGraph()
+    s = torch.cuda.Stream()
+    s.wait_stream(torch.cuda.current_stream())
+    #Warm up
+    with torch.cuda.stream(s):
+        for _ in range(10):
+            neighbors, distances, distance_vecs = nl(pos, batch)
+    torch.cuda.synchronize()
+    #Capture
+    with torch.cuda.graph(graph):
+        neighbors, distances, distance_vecs = nl(pos, batch)
+    neighbors.fill_(0)
+    graph.replay()
+    torch.cuda.synchronize()
+
+    neighbors = neighbors.cpu().detach().numpy()
+    distance_vecs = distance_vecs.cpu().detach().numpy()
+    distances = distances.cpu().detach().numpy()
+    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    assert neighbors.shape == (2, max_num_pairs)
+    assert distances.shape == (max_num_pairs,)
+    assert distance_vecs.shape == (max_num_pairs, 3)
+
+    assert np.allclose(neighbors, ref_neighbors)
+    assert np.allclose(distances, ref_distances)
+    assert np.allclose(distance_vecs, ref_distance_vecs)

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -12,7 +12,8 @@ def sort_neighbors(neighbors, deltas, distances):
 @pytest.mark.parametrize("strategy", ["brute", "cell"])
 @pytest.mark.parametrize("n_batches", [1, 2, 3, 4, 128])
 @pytest.mark.parametrize("cutoff", [0.1, 1.0, 1000.0])
-def test_neighbors(device, strategy, n_batches, cutoff):
+@pytest.mark.parametrize("loop", [True, False])
+def test_neighbors(device, strategy, n_batches, cutoff, loop):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     torch.manual_seed(4321)
@@ -26,6 +27,9 @@ def test_neighbors(device, strategy, n_batches, cutoff):
     pos[1,:] = torch.zeros(3)
     pos.requires_grad = True
     ref_neighbors = np.concatenate([np.tril_indices(int(n_atoms_per_batch[i]), -1)+cumsum[i] for i in range(n_batches)], axis=1)
+    if(loop): # Add self interactions
+        ilist=np.arange(cumsum[-1])
+        ref_neighbors = np.concatenate([ref_neighbors, np.stack([ilist, ilist], axis=0)], axis=1)
     pos_np = pos.cpu().detach().numpy()
     ref_distances = np.linalg.norm(pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], axis=-1)
     ref_distance_vecs = pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]]
@@ -37,7 +41,8 @@ def test_neighbors(device, strategy, n_batches, cutoff):
     ref_distances = ref_distances[mask]
     max_num_pairs = ref_neighbors.shape[1]
     box = torch.tensor([lbox, lbox, lbox])
-    nl = DistanceCellList(cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box)
+
+    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box)
     batch.to(device)
     neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors = neighbors.cpu().detach().numpy()

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -96,9 +96,15 @@ def test_neighbors(
     pos.requires_grad = True
     if box_type is None:
         box = None
-    else:
+    elif box_type == "rectangular":
         box = (
             torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]])
+            .to(pos.dtype)
+            .to(device)
+        )
+    elif box_type == "triclinic":
+        box = (
+            torch.tensor([[lbox, 0.0, 0.0], [0.1, lbox, 0.0], [0.3, 0.2, lbox]])
             .to(pos.dtype)
             .to(device)
         )

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -42,7 +42,7 @@ def test_neighbors(device, strategy, n_batches, cutoff, loop):
     max_num_pairs = ref_neighbors.shape[1]
     box = torch.tensor([lbox, lbox, lbox])
 
-    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box)
+    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True)
     batch.to(device)
     neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors = neighbors.cpu().detach().numpy()

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -5,19 +5,20 @@ import torch.jit
 import numpy as np
 from torchmdnet.models.utils import Distance, DistanceCellList
 
+
 def sort_neighbors(neighbors, deltas, distances):
     i_sorted = np.lexsort(neighbors)
     return neighbors[:, i_sorted], deltas[i_sorted], distances[i_sorted]
 
 
 def apply_pbc(deltas, box_vectors):
-    if(box_vectors is None):
+    if box_vectors is None:
         return deltas
     else:
         ref_vectors = box_vectors.cpu().detach().numpy()
-        deltas -= np.outer(np.round(deltas[:,2]/ref_vectors[2,2]), ref_vectors[2])
-        deltas -= np.outer(np.round(deltas[:,1]/ref_vectors[1,1]), ref_vectors[1])
-        deltas -= np.outer(np.round(deltas[:,0]/ref_vectors[0,0]), ref_vectors[0])
+        deltas -= np.outer(np.round(deltas[:, 2] / ref_vectors[2, 2]), ref_vectors[2])
+        deltas -= np.outer(np.round(deltas[:, 1] / ref_vectors[1, 1]), ref_vectors[1])
+        deltas -= np.outer(np.round(deltas[:, 0] / ref_vectors[0, 0]), ref_vectors[0])
         return deltas
 
 
@@ -25,25 +26,45 @@ def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box_vecto
     batch = batch.cpu()
     n_atoms_per_batch = torch.bincount(batch)
     n_batches = n_atoms_per_batch.shape[0]
-    cumsum = torch.cumsum(torch.cat([torch.tensor([0]), n_atoms_per_batch]), dim=0).cpu().detach().numpy()
-    ref_neighbors = np.concatenate([np.tril_indices(int(n_atoms_per_batch[i]), -1)+cumsum[i] for i in range(n_batches)], axis=1)
+    cumsum = (
+        torch.cumsum(torch.cat([torch.tensor([0]), n_atoms_per_batch]), dim=0)
+        .cpu()
+        .detach()
+        .numpy()
+    )
+    ref_neighbors = np.concatenate(
+        [
+            np.tril_indices(int(n_atoms_per_batch[i]), -1) + cumsum[i]
+            for i in range(n_batches)
+        ],
+        axis=1,
+    )
     # add the upper triangle
-    if(include_transpose):
-        ref_neighbors = np.concatenate([ref_neighbors, np.flip(ref_neighbors, axis=0)], axis=1)
-    if(loop): # Add self interactions
-        ilist=np.arange(cumsum[-1])
-        ref_neighbors = np.concatenate([ref_neighbors, np.stack([ilist, ilist], axis=0)], axis=1)
+    if include_transpose:
+        ref_neighbors = np.concatenate(
+            [ref_neighbors, np.flip(ref_neighbors, axis=0)], axis=1
+        )
+    if loop:  # Add self interactions
+        ilist = np.arange(cumsum[-1])
+        ref_neighbors = np.concatenate(
+            [ref_neighbors, np.stack([ilist, ilist], axis=0)], axis=1
+        )
     pos_np = pos.cpu().detach().numpy()
-    ref_distance_vecs = apply_pbc(pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], box_vectors)
+    ref_distance_vecs = apply_pbc(
+        pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], box_vectors
+    )
     ref_distances = np.linalg.norm(ref_distance_vecs, axis=-1)
 
-    #remove pairs with distance > cutoff
+    # remove pairs with distance > cutoff
     mask = ref_distances < cutoff
     ref_neighbors = ref_neighbors[:, mask]
     ref_distance_vecs = ref_distance_vecs[mask]
     ref_distances = ref_distances[mask]
-    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
+    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(
+        ref_neighbors, ref_distance_vecs, ref_distances
+    )
     return ref_neighbors, ref_distance_vecs, ref_distances
+
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
@@ -52,37 +73,58 @@ def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box_vecto
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
 @pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
-@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
-def test_neighbors(device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_neighbors(
+    device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype
+):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     if box_type == "triclinic" and strategy == "cell":
         pytest.skip("Triclinic only supported for brute force")
-    if device=="cpu" and strategy!="brute":
+    if device == "cpu" and strategy != "brute":
         pytest.skip("Only brute force supported on CPU")
     torch.manual_seed(4321)
     n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
-    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
-    lbox=10.0
-    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype)*lbox
-    #Ensure there is at least one pair
-    pos[0,:] = torch.zeros(3)
-    pos[1,:] = torch.zeros(3)
+    batch = torch.repeat_interleave(
+        torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch
+    ).to(device)
+    cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
+    lbox = 10.0
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox
+    # Ensure there is at least one pair
+    pos[0, :] = torch.zeros(3)
+    pos[1, :] = torch.zeros(3)
     pos.requires_grad = True
-    if(box_type is None):
+    if box_type is None:
         box = None
     else:
-        box = torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(pos.dtype).to(device)
-    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box)
+        box = (
+            torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]])
+            .to(pos.dtype)
+            .to(device)
+        )
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(
+        pos, batch, loop, include_transpose, cutoff, box
+    )
     max_num_pairs = ref_neighbors.shape[1]
-    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=include_transpose)
+    nl = DistanceCellList(
+        cutoff_lower=0.0,
+        loop=loop,
+        cutoff_upper=cutoff,
+        max_num_pairs=max_num_pairs,
+        strategy=strategy,
+        box=box,
+        return_vecs=True,
+        include_transpose=include_transpose,
+    )
     batch.to(device)
     neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
-    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    neighbors, distance_vecs, distances = sort_neighbors(
+        neighbors, distance_vecs, distances
+    )
     assert neighbors.shape == (2, max_num_pairs)
     assert distances.shape == (max_num_pairs,)
     assert distance_vecs.shape == (max_num_pairs, 3)
@@ -100,41 +142,63 @@ def test_neighbors(device, strategy, n_batches, cutoff, loop, include_transpose,
 def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
-    if device=="cpu" and strategy!="brute":
+    if device == "cpu" and strategy != "brute":
         pytest.skip("Only brute force supported on CPU")
 
     torch.manual_seed(4321)
     n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.long), n_atoms_per_batch).to(device)
-    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
-    lbox=10.0
-    pos = torch.rand(cumsum[-1], 3, device=device)*lbox
-    #Ensure there is at least one pair
-    pos[0,:] = torch.zeros(3)
-    pos[1,:] = torch.zeros(3)
+    batch = torch.repeat_interleave(
+        torch.arange(n_batches, dtype=torch.long), n_atoms_per_batch
+    ).to(device)
+    cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
+    lbox = 10.0
+    pos = torch.rand(cumsum[-1], 3, device=device) * lbox
+    # Ensure there is at least one pair
+    pos[0, :] = torch.zeros(3)
+    pos[1, :] = torch.zeros(3)
     pos.requires_grad = True
-    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, True, cutoff, None)
-    #Find the particle appearing in the most pairs
-    max_num_neighbors = torch.max(torch.bincount(torch.tensor(ref_neighbors[0,:])))
-    d = Distance(cutoff_lower=0.0, cutoff_upper=cutoff, loop=loop, max_num_neighbors=max_num_neighbors, return_vecs=True)
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(
+        pos, batch, loop, True, cutoff, None
+    )
+    # Find the particle appearing in the most pairs
+    max_num_neighbors = torch.max(torch.bincount(torch.tensor(ref_neighbors[0, :])))
+    d = Distance(
+        cutoff_lower=0.0,
+        cutoff_upper=cutoff,
+        loop=loop,
+        max_num_neighbors=max_num_neighbors,
+        return_vecs=True,
+    )
     ref_neighbors, ref_distances, ref_distance_vecs = d(pos, batch)
     ref_neighbors = ref_neighbors.cpu().detach().numpy()
     ref_distance_vecs = ref_distance_vecs.cpu().detach().numpy()
     ref_distances = ref_distances.cpu().detach().numpy()
-    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
+    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(
+        ref_neighbors, ref_distance_vecs, ref_distances
+    )
 
     max_num_pairs = ref_neighbors.shape[1]
     box = None
-    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=True)
+    nl = DistanceCellList(
+        cutoff_lower=0.0,
+        loop=loop,
+        cutoff_upper=cutoff,
+        max_num_pairs=max_num_pairs,
+        strategy=strategy,
+        box=box,
+        return_vecs=True,
+        include_transpose=True,
+    )
     neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
-    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    neighbors, distance_vecs, distances = sort_neighbors(
+        neighbors, distance_vecs, distances
+    )
     assert np.allclose(neighbors, ref_neighbors)
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
-
 
 
 @pytest.mark.parametrize("strategy", ["brute", "cell", "shared"])
@@ -146,69 +210,101 @@ def test_large_size(strategy, n_batches):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     torch.manual_seed(4321)
-    num_atoms=int(32000/n_batches)
-    n_atoms_per_batch = torch.ones(n_batches, dtype=torch.int64)*num_atoms
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
-    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
-    lbox=45.0
-    pos = torch.rand(cumsum[-1], 3, device=device)*lbox
-    #Ensure there is at least one pair
-    pos[0,:] = torch.zeros(3)
-    pos[1,:] = torch.zeros(3)
+    num_atoms = int(32000 / n_batches)
+    n_atoms_per_batch = torch.ones(n_batches, dtype=torch.int64) * num_atoms
+    batch = torch.repeat_interleave(
+        torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch
+    ).to(device)
+    cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
+    lbox = 45.0
+    pos = torch.rand(cumsum[-1], 3, device=device) * lbox
+    # Ensure there is at least one pair
+    pos[0, :] = torch.zeros(3)
+    pos[1, :] = torch.zeros(3)
     pos.requires_grad = True
-    #Find the particle appearing in the most pairs
+    # Find the particle appearing in the most pairs
     max_num_neighbors = 64
-    d = Distance(cutoff_lower=0.0, cutoff_upper=cutoff, loop=loop, max_num_neighbors=max_num_neighbors, return_vecs=True)
+    d = Distance(
+        cutoff_lower=0.0,
+        cutoff_upper=cutoff,
+        loop=loop,
+        max_num_neighbors=max_num_neighbors,
+        return_vecs=True,
+    )
     ref_neighbors, ref_distances, ref_distance_vecs = d(pos, batch)
     ref_neighbors = ref_neighbors.cpu().detach().numpy()
     ref_distance_vecs = ref_distance_vecs.cpu().detach().numpy()
     ref_distances = ref_distances.cpu().detach().numpy()
-    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
+    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(
+        ref_neighbors, ref_distance_vecs, ref_distances
+    )
 
     max_num_pairs = ref_neighbors.shape[1]
 
-    #Must check without PBC since Distance does not support it
+    # Must check without PBC since Distance does not support it
     box = None
-    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=True, resize_to_fit=True)
+    nl = DistanceCellList(
+        cutoff_lower=0.0,
+        loop=loop,
+        cutoff_upper=cutoff,
+        max_num_pairs=max_num_pairs,
+        strategy=strategy,
+        box=box,
+        return_vecs=True,
+        include_transpose=True,
+        resize_to_fit=True,
+    )
     neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
-    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    neighbors, distance_vecs, distances = sort_neighbors(
+        neighbors, distance_vecs, distances
+    )
     assert np.allclose(neighbors, ref_neighbors)
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
 
-@pytest.mark.parametrize('device', ['cpu', 'cuda'])
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
-@pytest.mark.parametrize('dtype', [torch.float32, torch.float64])
-@pytest.mark.parametrize('num_atoms', [1, 2, 3, 5, 100, 1000])
-@pytest.mark.parametrize('grad', ['deltas', 'distances', 'combined'])
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+@pytest.mark.parametrize("num_atoms", [1, 2, 3, 5, 100, 1000])
+@pytest.mark.parametrize("grad", ["deltas", "distances", "combined"])
 @pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
-def test_neighbor_grads(device, strategy, loop, include_transpose, dtype, num_atoms, grad, box_type):
-    if not torch.cuda.is_available() and device == 'cuda':
-        pytest.skip('No GPU')
-    if device=="cpu" and strategy!="brute":
+def test_neighbor_grads(
+    device, strategy, loop, include_transpose, dtype, num_atoms, grad, box_type
+):
+    if not torch.cuda.is_available() and device == "cuda":
+        pytest.skip("No GPU")
+    if device == "cpu" and strategy != "brute":
         pytest.skip("Only brute force supported on CPU")
     if box_type == "triclinic" and strategy == "cell":
         pytest.skip("Triclinic only supported for brute force")
-    cutoff=4.999999
-    lbox=10.0
+    cutoff = 4.999999
+    lbox = 10.0
     torch.random.manual_seed(1234)
     np.random.seed(123456)
     # Generate random positions
-    positions = 0.25*lbox * torch.rand(num_atoms, 3, device=device, dtype=dtype)
-    if(box_type is None):
+    positions = 0.25 * lbox * torch.rand(num_atoms, 3, device=device, dtype=dtype)
+    if box_type is None:
         box = None
     else:
-        box = torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(dtype).to(device)
+        box = (
+            torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]])
+            .to(dtype)
+            .to(device)
+        )
     # Compute reference values using pure pytorch
-    ref_neighbors = torch.vstack((torch.tril_indices(num_atoms,num_atoms, -1, device=device),))
+    ref_neighbors = torch.vstack(
+        (torch.tril_indices(num_atoms, num_atoms, -1, device=device),)
+    )
     if include_transpose:
-        ref_neighbors = torch.hstack((ref_neighbors, torch.stack((ref_neighbors[1], ref_neighbors[0]))))
+        ref_neighbors = torch.hstack(
+            (ref_neighbors, torch.stack((ref_neighbors[1], ref_neighbors[0])))
+        )
     if loop:
         index = torch.arange(num_atoms, device=device)
         ref_neighbors = torch.hstack((ref_neighbors, torch.stack((index, index))))
@@ -218,9 +314,15 @@ def test_neighbor_grads(device, strategy, loop, include_transpose, dtype, num_at
     ref_deltas = ref_positions[ref_neighbors[0]] - ref_positions[ref_neighbors[1]]
     if box is not None:
         ref_box = box.clone()
-        ref_deltas -= torch.outer(torch.round(ref_deltas[:,2]/ref_box[2,2]), ref_box[2])
-        ref_deltas -= torch.outer(torch.round(ref_deltas[:,1]/ref_box[1,1]), ref_box[1])
-        ref_deltas -= torch.outer(torch.round(ref_deltas[:,0]/ref_box[0,0]), ref_box[0])
+        ref_deltas -= torch.outer(
+            torch.round(ref_deltas[:, 2] / ref_box[2, 2]), ref_box[2]
+        )
+        ref_deltas -= torch.outer(
+            torch.round(ref_deltas[:, 1] / ref_box[1, 1]), ref_box[1]
+        )
+        ref_deltas -= torch.outer(
+            torch.round(ref_deltas[:, 0] / ref_box[0, 0]), ref_box[0]
+        )
 
     if loop:
         ref_distances = torch.zeros((ref_deltas.size(0),), device=device, dtype=dtype)
@@ -228,27 +330,44 @@ def test_neighbor_grads(device, strategy, loop, include_transpose, dtype, num_at
         ref_distances[mask] = torch.linalg.norm(ref_deltas[mask], dim=-1)
     else:
         ref_distances = torch.linalg.norm(ref_deltas, dim=-1)
-    max_num_pairs = max(ref_neighbors.shape[1],1)
+    max_num_pairs = max(ref_neighbors.shape[1], 1)
     positions.requires_grad_(True)
-    nl = DistanceCellList(cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, loop=loop, include_transpose=include_transpose, return_vecs=True, resize_to_fit=True, box=box)
+    nl = DistanceCellList(
+        cutoff_upper=cutoff,
+        max_num_pairs=max_num_pairs,
+        strategy=strategy,
+        loop=loop,
+        include_transpose=include_transpose,
+        return_vecs=True,
+        resize_to_fit=True,
+        box=box,
+    )
     neighbors, distances, deltas = nl(positions)
-    #Check neighbor pairs are correct
-    ref_neighbors_sort, _, _ = sort_neighbors(ref_neighbors.clone().cpu().detach().numpy(), ref_deltas.clone().cpu().detach().numpy(), ref_distances.clone().cpu().detach().numpy())
-    neighbors_sort, _, _ = sort_neighbors(neighbors.clone().cpu().detach().numpy(), deltas.clone().cpu().detach().numpy(), distances.clone().cpu().detach().numpy())
+    # Check neighbor pairs are correct
+    ref_neighbors_sort, _, _ = sort_neighbors(
+        ref_neighbors.clone().cpu().detach().numpy(),
+        ref_deltas.clone().cpu().detach().numpy(),
+        ref_distances.clone().cpu().detach().numpy(),
+    )
+    neighbors_sort, _, _ = sort_neighbors(
+        neighbors.clone().cpu().detach().numpy(),
+        deltas.clone().cpu().detach().numpy(),
+        distances.clone().cpu().detach().numpy(),
+    )
     assert np.allclose(ref_neighbors_sort, neighbors_sort)
 
     # Compute gradients
-    if grad == 'deltas':
+    if grad == "deltas":
         ref_deltas.sum().backward()
         deltas.sum().backward()
-    elif grad == 'distances':
+    elif grad == "distances":
         ref_distances.sum().backward()
         distances.sum().backward()
-    elif grad == 'combined':
+    elif grad == "combined":
         (ref_deltas.sum() + ref_distances.sum()).backward()
         (deltas.sum() + distances.sum()).backward()
     else:
-        raise ValueError('grad')
+        raise ValueError("grad")
     ref_pos_grad_sorted = ref_positions.grad.cpu().detach().numpy()
     pos_grad_sorted = positions.grad.cpu().detach().numpy()
     if dtype == torch.float32:
@@ -264,31 +383,50 @@ def test_neighbor_grads(device, strategy, loop, include_transpose, dtype, num_at
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
 @pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
-@pytest.mark.parametrize('dtype', [torch.float32])
-def test_jit_script_compatible(device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype):
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_jit_script_compatible(
+    device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype
+):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     if box_type == "triclinic" and strategy == "cell":
         pytest.skip("Triclinic only supported for brute force")
-    if device=="cpu" and strategy!="brute":
+    if device == "cpu" and strategy != "brute":
         pytest.skip("Only brute force supported on CPU")
     torch.manual_seed(4321)
     n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
-    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
-    lbox=10.0
-    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype)*lbox
-    #Ensure there is at least one pair
-    pos[0,:] = torch.zeros(3)
-    pos[1,:] = torch.zeros(3)
+    batch = torch.repeat_interleave(
+        torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch
+    ).to(device)
+    cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
+    lbox = 10.0
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox
+    # Ensure there is at least one pair
+    pos[0, :] = torch.zeros(3)
+    pos[1, :] = torch.zeros(3)
     pos.requires_grad = True
-    if(box_type is None):
+    if box_type is None:
         box = None
     else:
-        box = torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(pos.dtype).to(device)
-    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box)
+        box = (
+            torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]])
+            .to(pos.dtype)
+            .to(device)
+        )
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(
+        pos, batch, loop, include_transpose, cutoff, box
+    )
     max_num_pairs = ref_neighbors.shape[1]
-    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=include_transpose)
+    nl = DistanceCellList(
+        cutoff_lower=0.0,
+        loop=loop,
+        cutoff_upper=cutoff,
+        max_num_pairs=max_num_pairs,
+        strategy=strategy,
+        box=box,
+        return_vecs=True,
+        include_transpose=include_transpose,
+    )
     batch.to(device)
 
     nl = torch.jit.script(nl)
@@ -296,7 +434,9 @@ def test_jit_script_compatible(device, strategy, n_batches, cutoff, loop, includ
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
-    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    neighbors, distance_vecs, distances = sort_neighbors(
+        neighbors, distance_vecs, distances
+    )
     assert neighbors.shape == (2, max_num_pairs)
     assert distances.shape == (max_num_pairs,)
     assert distance_vecs.shape == (max_num_pairs, 3)
@@ -306,8 +446,6 @@ def test_jit_script_compatible(device, strategy, n_batches, cutoff, loop, includ
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
 
-
-
 @pytest.mark.parametrize("device", ["cuda"])
 @pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
 @pytest.mark.parametrize("n_batches", [1, 128])
@@ -315,41 +453,61 @@ def test_jit_script_compatible(device, strategy, n_batches, cutoff, loop, includ
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
 @pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
-@pytest.mark.parametrize('dtype', [torch.float32])
-def test_cuda_graph_compatible(device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype):
+@pytest.mark.parametrize("dtype", [torch.float32])
+def test_cuda_graph_compatible(
+    device, strategy, n_batches, cutoff, loop, include_transpose, box_type, dtype
+):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     if box_type == "triclinic" and strategy == "cell":
         pytest.skip("Triclinic only supported for brute force")
     torch.manual_seed(4321)
     n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
-    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
-    lbox=10.0
-    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype)*lbox
-    #Ensure there is at least one pair
-    pos[0,:] = torch.zeros(3)
-    pos[1,:] = torch.zeros(3)
+    batch = torch.repeat_interleave(
+        torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch
+    ).to(device)
+    cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
+    lbox = 10.0
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox
+    # Ensure there is at least one pair
+    pos[0, :] = torch.zeros(3)
+    pos[1, :] = torch.zeros(3)
     pos.requires_grad = True
-    if(box_type is None):
+    if box_type is None:
         box = None
     else:
-        box = torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(pos.dtype).to(device)
-    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box)
+        box = (
+            torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]])
+            .to(pos.dtype)
+            .to(device)
+        )
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(
+        pos, batch, loop, include_transpose, cutoff, box
+    )
     max_num_pairs = ref_neighbors.shape[1]
-    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=include_transpose, check_errors=False, resize_to_fit=False)
+    nl = DistanceCellList(
+        cutoff_lower=0.0,
+        loop=loop,
+        cutoff_upper=cutoff,
+        max_num_pairs=max_num_pairs,
+        strategy=strategy,
+        box=box,
+        return_vecs=True,
+        include_transpose=include_transpose,
+        check_errors=False,
+        resize_to_fit=False,
+    )
     batch.to(device)
-
 
     graph = torch.cuda.CUDAGraph()
     s = torch.cuda.Stream()
     s.wait_stream(torch.cuda.current_stream())
-    #Warm up
+    # Warm up
     with torch.cuda.stream(s):
         for _ in range(10):
             neighbors, distances, distance_vecs = nl(pos, batch)
     torch.cuda.synchronize()
-    #Capture
+    # Capture
     with torch.cuda.graph(graph):
         neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors.fill_(0)
@@ -359,7 +517,9 @@ def test_cuda_graph_compatible(device, strategy, n_batches, cutoff, loop, includ
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
-    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    neighbors, distance_vecs, distances = sort_neighbors(
+        neighbors, distance_vecs, distances
+    )
     assert neighbors.shape == (2, max_num_pairs)
     assert distances.shape == (max_num_pairs,)
     assert distance_vecs.shape == (max_num_pairs, 3)

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -89,7 +89,7 @@ def test_neighbors(
     ).to(device)
     cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
     lbox = 10.0
-    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox - 10.0*lbox
     # Ensure there is at least one pair
     pos[0, :] = torch.zeros(3)
     pos[1, :] = torch.zeros(3)

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -66,8 +66,7 @@ def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box_vecto
     return ref_neighbors, ref_distance_vecs, ref_distances
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-@pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
+@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
 @pytest.mark.parametrize("n_batches", [1, 2, 3, 4, 128])
 @pytest.mark.parametrize("cutoff", [0.1, 1.0, 3.0, 4.9])
 @pytest.mark.parametrize("loop", [True, False])
@@ -80,7 +79,7 @@ def test_neighbors(
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     if box_type == "triclinic" and strategy == "cell":
-        pytest.skip("Triclinic only supported for brute force")
+        pytest.skip("Triclinic not supported for cell")
     if device == "cpu" and strategy != "brute":
         pytest.skip("Only brute force supported on CPU")
     torch.manual_seed(4321)
@@ -134,8 +133,7 @@ def test_neighbors(
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-@pytest.mark.parametrize("strategy", ["brute", "cell", "shared"])
+@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
 @pytest.mark.parametrize("n_batches", [1, 2, 3, 4])
 @pytest.mark.parametrize("cutoff", [0.1, 1.0, 1000.0])
 @pytest.mark.parametrize("loop", [True, False])
@@ -267,8 +265,7 @@ def test_large_size(strategy, n_batches):
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-@pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
+@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
@@ -377,8 +374,7 @@ def test_neighbor_grads(
         assert np.allclose(ref_pos_grad_sorted, pos_grad_sorted, atol=1e-8, rtol=1e-5)
 
 
-@pytest.mark.parametrize("device", ["cpu", "cuda"])
-@pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
+@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
 @pytest.mark.parametrize("n_batches", [1, 128])
 @pytest.mark.parametrize("cutoff", [1.0])
 @pytest.mark.parametrize("loop", [True, False])

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -41,7 +41,7 @@ def test_neighbors(device, strategy, n_batches, cutoff, loop):
         pytest.skip("CUDA not available")
     torch.manual_seed(4321)
     n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
-    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int32), n_atoms_per_batch).to(device)
+    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
     cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
     lbox=10.0
     pos = torch.rand(cumsum[-1], 3, device=device)*lbox
@@ -100,9 +100,7 @@ def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
     max_num_pairs = ref_neighbors.shape[1]
     box = torch.tensor([lbox, lbox, lbox])
     nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True)
-    batch = batch.to(torch.int32).to(device)
     neighbors, distances, distance_vecs = nl(pos, batch)
-
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -9,7 +9,18 @@ def sort_neighbors(neighbors, deltas, distances):
     return neighbors[:, i_sorted], deltas[i_sorted], distances[i_sorted]
 
 
-def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff):
+def apply_pbc(deltas, box_vectors):
+    if(box_vectors is None):
+        return deltas
+    else:
+        ref_vectors = box_vectors.cpu().detach().numpy()
+        deltas -= np.outer(np.round(deltas[:,2]/ref_vectors[2,2]), ref_vectors[2])
+        deltas -= np.outer(np.round(deltas[:,1]/ref_vectors[1,1]), ref_vectors[1])
+        deltas -= np.outer(np.round(deltas[:,0]/ref_vectors[0,0]), ref_vectors[0])
+        return deltas
+
+
+def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box_vectors):
     batch = batch.cpu()
     n_atoms_per_batch = torch.bincount(batch)
     n_batches = n_atoms_per_batch.shape[0]
@@ -22,8 +33,9 @@ def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff):
         ilist=np.arange(cumsum[-1])
         ref_neighbors = np.concatenate([ref_neighbors, np.stack([ilist, ilist], axis=0)], axis=1)
     pos_np = pos.cpu().detach().numpy()
-    ref_distances = np.linalg.norm(pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], axis=-1)
-    ref_distance_vecs = pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]]
+    ref_distance_vecs = apply_pbc(pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], box_vectors)
+    ref_distances = np.linalg.norm(ref_distance_vecs, axis=-1)
+
     #remove pairs with distance > cutoff
     mask = ref_distances < cutoff
     ref_neighbors = ref_neighbors[:, mask]
@@ -35,12 +47,15 @@ def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff):
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("strategy", ["brute", "cell"])
 @pytest.mark.parametrize("n_batches", [1, 2, 3, 4, 128])
-@pytest.mark.parametrize("cutoff", [0.1, 1.0, 1000.0])
+@pytest.mark.parametrize("cutoff", [0.1, 1.0, 3.0, 4.9])
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
-def test_neighbors(device, strategy, n_batches, cutoff, loop, include_transpose):
+@pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
+def test_neighbors(device, strategy, n_batches, cutoff, loop, include_transpose, box_type):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
+    if box_type == "triclinic" and strategy == "cell":
+        pytest.skip("Triclinic only supported for brute force")
     torch.manual_seed(4321)
     n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
     batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
@@ -51,10 +66,12 @@ def test_neighbors(device, strategy, n_batches, cutoff, loop, include_transpose)
     pos[0,:] = torch.zeros(3)
     pos[1,:] = torch.zeros(3)
     pos.requires_grad = True
-    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff)
+    if(box_type is None):
+        box = None
+    else:
+        box = torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(pos.dtype).to(device)
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box)
     max_num_pairs = ref_neighbors.shape[1]
-    box = torch.tensor([lbox, lbox, lbox])
-
     nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=include_transpose)
     batch.to(device)
     neighbors, distances, distance_vecs = nl(pos, batch)
@@ -89,7 +106,7 @@ def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
     pos[0,:] = torch.zeros(3)
     pos[1,:] = torch.zeros(3)
     pos.requires_grad = True
-    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, True, cutoff)
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, True, cutoff, None)
     #Find the particle appearing in the most pairs
     max_num_neighbors = torch.max(torch.bincount(torch.tensor(ref_neighbors[0,:])))
     d = Distance(cutoff_lower=0.0, cutoff_upper=cutoff, loop=loop, max_num_neighbors=max_num_neighbors, return_vecs=True)
@@ -100,8 +117,52 @@ def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
     ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
 
     max_num_pairs = ref_neighbors.shape[1]
-    box = torch.tensor([lbox, lbox, lbox])
+    box = None
     nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=True)
+    neighbors, distances, distance_vecs = nl(pos, batch)
+    neighbors = neighbors.cpu().detach().numpy()
+    distance_vecs = distance_vecs.cpu().detach().numpy()
+    distances = distances.cpu().detach().numpy()
+    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
+    assert np.allclose(neighbors, ref_neighbors)
+    assert np.allclose(distances, ref_distances)
+    assert np.allclose(distance_vecs, ref_distance_vecs)
+
+
+
+@pytest.mark.parametrize("strategy", ["brute", "cell"])
+@pytest.mark.parametrize("n_batches", [1, 2, 3, 4])
+def test_large_size(strategy, n_batches):
+    device = "cuda"
+    cutoff = 1.76
+    loop = False
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    torch.manual_seed(4321)
+    num_atoms=int(32000/n_batches)
+    n_atoms_per_batch = torch.ones(n_batches, dtype=torch.int64)*num_atoms
+    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.int64), n_atoms_per_batch).to(device)
+    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
+    lbox=45.0
+    pos = torch.rand(cumsum[-1], 3, device=device)*lbox
+    #Ensure there is at least one pair
+    pos[0,:] = torch.zeros(3)
+    pos[1,:] = torch.zeros(3)
+    pos.requires_grad = True
+    #Find the particle appearing in the most pairs
+    max_num_neighbors = 64
+    d = Distance(cutoff_lower=0.0, cutoff_upper=cutoff, loop=loop, max_num_neighbors=max_num_neighbors, return_vecs=True)
+    ref_neighbors, ref_distances, ref_distance_vecs = d(pos, batch)
+    ref_neighbors = ref_neighbors.cpu().detach().numpy()
+    ref_distance_vecs = ref_distance_vecs.cpu().detach().numpy()
+    ref_distances = ref_distances.cpu().detach().numpy()
+    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
+
+    max_num_pairs = ref_neighbors.shape[1]
+
+    #Must check without PBC since Distance does not support it
+    box = None #torch.tensor([[lbox, 0.0, 0.0], [0.0, lbox, 0.0], [0.0, 0.0, lbox]]).to(pos.dtype).to(device)
+    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True, include_transpose=True, resize_to_fit=True)
     neighbors, distances, distance_vecs = nl(pos, batch)
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -3,7 +3,7 @@ import pytest
 import torch
 import torch.jit
 import numpy as np
-from torchmdnet.models.utils import Distance, DistanceCellList
+from torchmdnet.models.utils import Distance, OptimizedDistance
 
 
 def sort_neighbors(neighbors, deltas, distances):
@@ -106,7 +106,7 @@ def test_neighbors(
         pos, batch, loop, include_transpose, cutoff, box
     )
     max_num_pairs = ref_neighbors.shape[1]
-    nl = DistanceCellList(
+    nl = OptimizedDistance(
         cutoff_lower=0.0,
         loop=loop,
         cutoff_upper=cutoff,
@@ -178,7 +178,7 @@ def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop, dty
 
     max_num_pairs = ref_neighbors.shape[1]
     box = None
-    nl = DistanceCellList(
+    nl = OptimizedDistance(
         cutoff_lower=0.0,
         loop=loop,
         cutoff_upper=cutoff,
@@ -242,7 +242,7 @@ def test_large_size(strategy, n_batches):
 
     # Must check without PBC since Distance does not support it
     box = None
-    nl = DistanceCellList(
+    nl = OptimizedDistance(
         cutoff_lower=0.0,
         loop=loop,
         cutoff_upper=cutoff,
@@ -330,7 +330,7 @@ def test_neighbor_grads(
         ref_distances = torch.linalg.norm(ref_deltas, dim=-1)
     max_num_pairs = max(ref_neighbors.shape[1], 1)
     positions.requires_grad_(True)
-    nl = DistanceCellList(
+    nl = OptimizedDistance(
         cutoff_upper=cutoff,
         max_num_pairs=max_num_pairs,
         strategy=strategy,
@@ -414,7 +414,7 @@ def test_jit_script_compatible(
         pos, batch, loop, include_transpose, cutoff, box
     )
     max_num_pairs = ref_neighbors.shape[1]
-    nl = DistanceCellList(
+    nl = OptimizedDistance(
         cutoff_lower=0.0,
         loop=loop,
         cutoff_upper=cutoff,
@@ -482,7 +482,7 @@ def test_cuda_graph_compatible(
         pos, batch, loop, include_transpose, cutoff, box
     )
     max_num_pairs = ref_neighbors.shape[1]
-    nl = DistanceCellList(
+    nl = OptimizedDistance(
         cutoff_lower=0.0,
         loop=loop,
         cutoff_upper=cutoff,

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -2,11 +2,34 @@ import os
 import pytest
 import torch
 import numpy as np
-from torchmdnet.models.utils import DistanceCellList
+from torchmdnet.models.utils import Distance, DistanceCellList
 
 def sort_neighbors(neighbors, deltas, distances):
     i_sorted = np.lexsort(neighbors)
     return neighbors[:, i_sorted], deltas[i_sorted], distances[i_sorted]
+
+
+def compute_ref_neighbors(pos, batch, loop, cutoff):
+    batch = batch.cpu()
+    n_atoms_per_batch = torch.bincount(batch)
+    n_batches = n_atoms_per_batch.shape[0]
+    cumsum = torch.cumsum(torch.cat([torch.tensor([0]), n_atoms_per_batch]), dim=0).cpu().detach().numpy()
+    ref_neighbors = np.concatenate([np.tril_indices(int(n_atoms_per_batch[i]), -1)+cumsum[i] for i in range(n_batches)], axis=1)
+    #add the upper triangle
+    ref_neighbors = np.concatenate([ref_neighbors, np.flip(ref_neighbors, axis=0)], axis=1)
+    if(loop): # Add self interactions
+        ilist=np.arange(cumsum[-1])
+        ref_neighbors = np.concatenate([ref_neighbors, np.stack([ilist, ilist], axis=0)], axis=1)
+    pos_np = pos.cpu().detach().numpy()
+    ref_distances = np.linalg.norm(pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], axis=-1)
+    ref_distance_vecs = pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]]
+    #remove pairs with distance > cutoff
+    mask = ref_distances < cutoff
+    ref_neighbors = ref_neighbors[:, mask]
+    ref_distance_vecs = ref_distance_vecs[mask]
+    ref_distances = ref_distances[mask]
+    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
+    return ref_neighbors, ref_distance_vecs, ref_distances
 
 @pytest.mark.parametrize("device", ["cpu", "cuda"])
 @pytest.mark.parametrize("strategy", ["brute", "cell"])
@@ -26,19 +49,7 @@ def test_neighbors(device, strategy, n_batches, cutoff, loop):
     pos[0,:] = torch.zeros(3)
     pos[1,:] = torch.zeros(3)
     pos.requires_grad = True
-    ref_neighbors = np.concatenate([np.tril_indices(int(n_atoms_per_batch[i]), -1)+cumsum[i] for i in range(n_batches)], axis=1)
-    if(loop): # Add self interactions
-        ilist=np.arange(cumsum[-1])
-        ref_neighbors = np.concatenate([ref_neighbors, np.stack([ilist, ilist], axis=0)], axis=1)
-    pos_np = pos.cpu().detach().numpy()
-    ref_distances = np.linalg.norm(pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]], axis=-1)
-    ref_distance_vecs = pos_np[ref_neighbors[0]] - pos_np[ref_neighbors[1]]
-    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
-    #remove pairs with distance > cutoff
-    mask = ref_distances < cutoff
-    ref_neighbors = ref_neighbors[:, mask]
-    ref_distance_vecs = ref_distance_vecs[mask]
-    ref_distances = ref_distances[mask]
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, cutoff)
     max_num_pairs = ref_neighbors.shape[1]
     box = torch.tensor([lbox, lbox, lbox])
 
@@ -48,9 +59,53 @@ def test_neighbors(device, strategy, n_batches, cutoff, loop):
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
+    neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
     assert neighbors.shape == (2, max_num_pairs)
     assert distances.shape == (max_num_pairs,)
     assert distance_vecs.shape == (max_num_pairs, 3)
+
+    assert np.allclose(neighbors, ref_neighbors)
+    assert np.allclose(distances, ref_distances)
+    assert np.allclose(distance_vecs, ref_distance_vecs)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("strategy", ["brute", "cell"])
+@pytest.mark.parametrize("n_batches", [1, 2, 3, 4])
+@pytest.mark.parametrize("cutoff", [0.1, 1.0, 1000.0])
+@pytest.mark.parametrize("loop", [True, False])
+def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    torch.manual_seed(4321)
+    n_atoms_per_batch = torch.randint(3, 100, size=(n_batches,))
+    batch = torch.repeat_interleave(torch.arange(n_batches, dtype=torch.long), n_atoms_per_batch).to(device)
+    cumsum = np.cumsum( np.concatenate([[0], n_atoms_per_batch]))
+    lbox=10.0
+    pos = torch.rand(cumsum[-1], 3, device=device)*lbox
+    #Ensure there is at least one pair
+    pos[0,:] = torch.zeros(3)
+    pos[1,:] = torch.zeros(3)
+    pos.requires_grad = True
+    ref_neighbors, ref_distance_vecs, ref_distances = compute_ref_neighbors(pos, batch, loop, cutoff)
+    #Find the particle appearing in the most pairs
+    max_num_neighbors = torch.max(torch.bincount(torch.tensor(ref_neighbors[0,:])))
+    d = Distance(cutoff_lower=0.0, cutoff_upper=cutoff, loop=loop, max_num_neighbors=max_num_neighbors, return_vecs=True)
+    ref_neighbors, ref_distances, ref_distance_vecs = d(pos, batch)
+    ref_neighbors = ref_neighbors.cpu().detach().numpy()
+    ref_distance_vecs = ref_distance_vecs.cpu().detach().numpy()
+    ref_distances = ref_distances.cpu().detach().numpy()
+    ref_neighbors, ref_distance_vecs, ref_distances = sort_neighbors(ref_neighbors, ref_distance_vecs, ref_distances)
+
+    max_num_pairs = ref_neighbors.shape[1]
+    box = torch.tensor([lbox, lbox, lbox])
+    nl = DistanceCellList(cutoff_lower=0.0, loop=loop, cutoff_upper=cutoff, max_num_pairs=max_num_pairs, strategy=strategy, box=box, return_vecs=True)
+    batch = batch.to(torch.int32).to(device)
+    neighbors, distances, distance_vecs = nl(pos, batch)
+
+    neighbors = neighbors.cpu().detach().numpy()
+    distance_vecs = distance_vecs.cpu().detach().numpy()
+    distances = distances.cpu().detach().numpy()
     neighbors, distance_vecs, distances = sort_neighbors(neighbors, distance_vecs, distances)
     assert np.allclose(neighbors, ref_neighbors)
     assert np.allclose(distances, ref_distances)

--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -139,7 +139,8 @@ def test_neighbors(
 @pytest.mark.parametrize("n_batches", [1, 2, 3, 4])
 @pytest.mark.parametrize("cutoff", [0.1, 1.0, 1000.0])
 @pytest.mark.parametrize("loop", [True, False])
-def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
+@pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
+def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop, dtype):
     if device == "cuda" and not torch.cuda.is_available():
         pytest.skip("CUDA not available")
     if device == "cpu" and strategy != "brute":
@@ -152,7 +153,7 @@ def test_compatible_with_distance(device, strategy, n_batches, cutoff, loop):
     ).to(device)
     cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
     lbox = 10.0
-    pos = torch.rand(cumsum[-1], 3, device=device) * lbox
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox
     # Ensure there is at least one pair
     pos[0, :] = torch.zeros(3)
     pos[1, :] = torch.zeros(3)

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -6,6 +6,7 @@ from torch import nn
 import torch.nn.functional as F
 from torch_geometric.nn import MessagePassing
 from torch_cluster import radius_graph
+import torchmdnet.neighbors as neighbors
 import warnings
 
 
@@ -77,7 +78,7 @@ class NeighborEmbedding(MessagePassing):
     def message(self, x_j, W):
         return x_j * W
 
-import torchmdnet.neighbors as neighbors
+
 class DistanceCellList(torch.nn.Module):
 
     def __init__(

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -127,7 +127,7 @@ class DistanceCellList(torch.nn.Module):
         self.cutoff_lower = cutoff_lower
         self.max_num_pairs = max_num_pairs
         self.strategy = strategy
-        self.box = box
+        self.box: Optional[Tensor] = box
         self.loop = loop
         self.return_vecs = return_vecs
         self.include_transpose = include_transpose
@@ -135,6 +135,7 @@ class DistanceCellList(torch.nn.Module):
         self.use_periodic = True
         if self.box is None:
             self.use_periodic = False
+            self.box = torch.empty((0,0))
             if self.strategy == "cell":
                 #Default the box to 3 times the cutoff, really inefficient for the cell list
                 lbox = cutoff_upper * 3.0
@@ -169,8 +170,6 @@ class DistanceCellList(torch.nn.Module):
         otherwise the tensors will have size max_num_pairs, with neighbor pairs (-1, -1) at the end.
 
         """
-        if self.box is None:
-            self.box = torch.empty((0, 0), dtype=pos.dtype)
         self.box = self.box.to(pos.dtype).to(pos.device)
         max_pairs = self.max_num_pairs
         if self.max_num_pairs < 0:

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -83,6 +83,7 @@ class DistanceCellList(torch.nn.Module):
             cutoff_upper,
             cutoff_lower=0.0,
             max_num_pairs=32,
+            return_vecs=False,
             loop=False,
             strategy="cell",
             box=None
@@ -104,6 +105,8 @@ class DistanceCellList(torch.nn.Module):
             Size of the box shape (3,) or None
         loop : bool
             Whether to include self-interactions.
+        return_vecs : bool
+            Whether to return the distance vectors.
 
         """
         self.cutoff_upper = cutoff_upper
@@ -149,7 +152,10 @@ class DistanceCellList(torch.nn.Module):
             check_errors=True,
             box_size=self.box
         )
-        return neighbors, distances, distance_vecs
+        if self.return_vecs:
+            return neighbors, distances, distance_vecs
+        else:
+            return neighbors, distances, None
 
 class GaussianSmearing(nn.Module):
     def __init__(self, cutoff_lower=0.0, cutoff_upper=5.0, num_rbf=50, trainable=True):

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -109,6 +109,9 @@ class DistanceCellList(torch.nn.Module):
         strategy : str
             Strategy to use for computing the neighbor list. Can be one of
             ["shared", "brute", "cell"].
+            Shared: An O(N^2) algorithm that leverages CUDA shared memory, best for large number of particles.
+            Brute: A brute force O(N^2) algorithm, best for small number of particles.
+            Cell:  A cell list algorithm, best for large number of particles, low cutoffs and low batch size.
         box : Optional[torch.Tensor]
             Size of the box, shape (3,3) or None.
             If strategy is "cell", the box must be diagonal.

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -106,7 +106,8 @@ class OptimizedDistance(torch.nn.Module):
         cutoff_upper : float
             Upper cutoff for the neighbor list.
         max_num_pairs : int
-            Maximum number of pairs to store.
+            Maximum number of pairs to store, if the number of pairs found is less than this, the list is padded with (-1,-1) pairs up to max_num_pairs unless resize_to_fit is True, in which case the list is resized to the actual number of pairs found.
+            If the number of pairs found is larger than this, the pairs are randomly sampled. When check_errors is True, an exception is raised in this case.
             If negative, it is interpreted as (minus) the maximum number of neighbors per atom.
         strategy : str
             Strategy to use for computing the neighbor list. Can be one of

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -133,13 +133,13 @@ class DistanceCellList(torch.nn.Module):
         -------
         neighbors : torch.Tensor
           List of neighbors for each atom in the batch.
-        shape (2, max_num_pairs)
+        shape (2, num_found_pairs)
         distances : torch.Tensor
             List of distances for each atom in the batch.
-        shape (max_num_pairs,)
+        shape (num_found_pairs,)
         distance_vecs : torch.Tensor
             List of distance vectors for each atom in the batch.
-        shape (max_num_pairs, 3)
+        shape (num_found_pairs, 3)
 
         """
         function = get_neighbor_pairs if self.strategy == "brute" else get_neighbor_pairs_cell
@@ -153,6 +153,12 @@ class DistanceCellList(torch.nn.Module):
             check_errors=True,
             box_size=self.box
         )
+        #Remove (-1,-1)  pairs
+        mask = neighbors[0] != -1
+        neighbors = neighbors[:, mask]
+        distances = distances[mask]
+        distance_vecs = distance_vecs[mask,:]
+
         if self.return_vecs:
             return neighbors, distances, distance_vecs
         else:

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -79,7 +79,7 @@ class NeighborEmbedding(MessagePassing):
         return x_j * W
 
 
-class DistanceCellList(torch.nn.Module):
+class OptimizedDistance(torch.nn.Module):
 
     def __init__(
         self,
@@ -94,7 +94,7 @@ class DistanceCellList(torch.nn.Module):
         check_errors=True,
         box=None,
     ):
-        super(DistanceCellList, self).__init__()
+        super(OptimizedDistance, self).__init__()
         """ Compute the neighbor list for a given cutoff.
         This operation can be placed inside a CUDA graph in some cases.
         In particular, resize_to_fit and check_errors must be False.

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -97,6 +97,7 @@ class DistanceCellList(torch.nn.Module):
         """ Compute the neighbor list for a given cutoff.
         This operation can be placed inside a CUDA graph in some cases.
         In particular, resize_to_fit and check_errors must be False.
+        Note that this module returns neighbors such that distance(i,j) >= cutoff_lower and distance(i,j) < cutoff_upper.
         Parameters
         ----------
         cutoff_lower : float

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -115,6 +115,7 @@ class DistanceCellList(torch.nn.Module):
         self.strategy = strategy
         self.box = box
         self.loop = loop
+        self.return_vecs = return_vecs
         #Default the box to 3 times the cutoff
         if self.box is None and self.strategy == "cell":
             self.box = torch.tensor([cutoff_upper * 3] * 3)

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -1,6 +1,7 @@
 import math
-from typing import Optional
+from typing import Optional, Tuple
 import torch
+from torch import Tensor
 from torch import nn
 import torch.nn.functional as F
 from torch_geometric.nn import MessagePassing
@@ -144,13 +145,13 @@ class DistanceCellList(torch.nn.Module):
             raise ValueError("Unknown strategy: {}".format(self.strategy))
         self.check_errors = check_errors
 
-    def forward(self, pos, batch):
-        """
+    def forward(self, pos: Tensor, batch: Optional[Tensor] = None) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
+        """ Compute the neighbor list for a given cutoff.
         Parameters
         ----------
         pos : torch.Tensor
             shape (N, 3)
-        batch : torch.Tensor
+        batch : torch.Tensor or None
             shape (N,)
         Returns
         -------
@@ -174,6 +175,8 @@ class DistanceCellList(torch.nn.Module):
         max_pairs = self.max_num_pairs
         if self.max_num_pairs < 0:
             max_pairs = -self.max_num_pairs*pos.shape[0]
+        if batch is None:
+            batch = torch.zeros(pos.shape[0], dtype=torch.long, device=pos.device)
         neighbors, distance_vecs, distances, num_pairs = self.kernel(
             pos,
             cutoff_lower=self.cutoff_lower,

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -77,20 +77,7 @@ class NeighborEmbedding(MessagePassing):
     def message(self, x_j, W):
         return x_j * W
 
-
-from torchmdnet.neighbors import (
-    get_neighbor_pairs_brute,
-    get_neighbor_pairs_cell,
-    get_neighbor_pairs_shared,
-)
-
-
 class DistanceCellList(torch.nn.Module):
-    _backends = {
-        "brute": get_neighbor_pairs_brute,
-        "cell": get_neighbor_pairs_cell,
-        "shared": get_neighbor_pairs_shared,
-    }
 
     def __init__(
         self,
@@ -154,6 +141,17 @@ class DistanceCellList(torch.nn.Module):
                 lbox = cutoff_upper * 3.0
                 self.box = torch.tensor([[lbox, 0, 0], [0, lbox, 0], [0, 0, lbox]])
         self.box = self.box.cpu()  # All strategies expect the box to be in CPU memory
+        from torchmdnet.neighbors import (
+            get_neighbor_pairs_brute,
+            get_neighbor_pairs_cell,
+            get_neighbor_pairs_shared,
+        )
+        self._backends = {
+            "brute": get_neighbor_pairs_brute,
+            "cell": get_neighbor_pairs_cell,
+            "shared": get_neighbor_pairs_shared,
+        }
+
         self.kernel = self._backends[self.strategy]
         if self.kernel is None:
             raise ValueError("Unknown strategy: {}".format(self.strategy))

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -215,6 +215,7 @@ class DistanceCellList(torch.nn.Module):
             neighbors = neighbors[:, mask]
             distances = distances[mask]
             distance_vecs = distance_vecs[mask, :]
+        neighbors = neighbors.to(torch.long)
         if self.return_vecs:
             return neighbors, distances, distance_vecs
         else:

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -96,7 +96,7 @@ class DistanceCellList(torch.nn.Module):
         self,
         cutoff_lower=0.0,
         cutoff_upper=5.0,
-        max_num_pairs=32,
+        max_num_pairs=-32,
         return_vecs=False,
         loop=False,
         strategy="brute",
@@ -203,10 +203,10 @@ class DistanceCellList(torch.nn.Module):
             use_periodic=self.use_periodic,
         )
         if self.check_errors:
-            if num_pairs[0] > self.max_num_pairs:
+            if num_pairs[0] > max_pairs:
                 raise RuntimeError(
                     "Found num_pairs({}) > max_num_pairs({})".format(
-                        num_pairs[0], self.max_num_pairs
+                        num_pairs[0], max_pairs
                     )
                 )
         # Remove (-1,-1)  pairs

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -102,7 +102,7 @@ class DistanceCellList(torch.nn.Module):
         strategy="brute",
         include_transpose=True,
         resize_to_fit=True,
-        check_errors=False,
+        check_errors=True,
         box=None,
     ):
         super(DistanceCellList, self).__init__()

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -77,6 +77,7 @@ class NeighborEmbedding(MessagePassing):
     def message(self, x_j, W):
         return x_j * W
 
+import torchmdnet.neighbors as neighbors
 class DistanceCellList(torch.nn.Module):
 
     def __init__(
@@ -141,17 +142,7 @@ class DistanceCellList(torch.nn.Module):
                 lbox = cutoff_upper * 3.0
                 self.box = torch.tensor([[lbox, 0, 0], [0, lbox, 0], [0, 0, lbox]])
         self.box = self.box.cpu()  # All strategies expect the box to be in CPU memory
-        from torchmdnet.neighbors import (
-            get_neighbor_pairs_brute,
-            get_neighbor_pairs_cell,
-            get_neighbor_pairs_shared,
-        )
-        self._backends = {
-            "brute": get_neighbor_pairs_brute,
-            "cell": get_neighbor_pairs_cell,
-            "shared": get_neighbor_pairs_shared,
-        }
-
+        self._backends = neighbors.get_backends()
         self.kernel = self._backends[self.strategy]
         if self.kernel is None:
             raise ValueError("Unknown strategy: {}".format(self.strategy))

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -2,11 +2,20 @@ import os
 import torch as pt
 from torch.utils import cpp_extension
 
-src_dir = os.path.dirname(__file__)
-sources = ['neighbors.cpp', 'neighbors_cpu.cpp'] + (['neighbors_cuda.cu', 'neighbors_cuda_cell.cu', 'backwards.cu'] if pt.cuda.is_available() else [])
-sources = [os.path.join(src_dir, name) for name in sources]
-cpp_extension.load(name='neighbors', sources=sources, is_python_module=False)
 
-get_neighbor_pairs_brute = pt.ops.neighbors.get_neighbor_pairs_brute
-get_neighbor_pairs_shared = pt.ops.neighbors.get_neighbor_pairs_shared
-get_neighbor_pairs_cell = pt.ops.neighbors.get_neighbor_pairs_cell
+def compile_extension():
+    src_dir = os.path.dirname(__file__)
+    sources = ['neighbors.cpp', 'neighbors_cpu.cpp'] + (['neighbors_cuda.cu', 'neighbors_cuda_cell.cu', 'backwards.cu'] if pt.cuda.is_available() else [])
+    sources = [os.path.join(src_dir, name) for name in sources]
+    cpp_extension.load(name='neighbors', sources=sources, is_python_module=False)
+
+def get_backends():
+    compile_extension()
+    get_neighbor_pairs_brute = pt.ops.neighbors.get_neighbor_pairs_brute
+    get_neighbor_pairs_shared = pt.ops.neighbors.get_neighbor_pairs_shared
+    get_neighbor_pairs_cell = pt.ops.neighbors.get_neighbor_pairs_cell
+    return {
+            "brute": get_neighbor_pairs_brute,
+            "cell": get_neighbor_pairs_cell,
+            "shared": get_neighbor_pairs_shared,
+    }

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -11,7 +11,7 @@ def compile_extension():
         else []
     )
     sources = [os.path.join(src_dir, name) for name in sources]
-    cpp_extension.load(name="torchmdnet_neighbors", sources=sources, is_python_module=False, verbose=True)
+    cpp_extension.load(name="torchmdnet_neighbors", sources=sources, is_python_module=False)
 
 
 def get_backends():

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -6,7 +6,7 @@ from torch.utils import cpp_extension
 def compile_extension():
     src_dir = os.path.dirname(__file__)
     sources = ["neighbors.cpp", "neighbors_cpu.cpp"] + (
-        ["neighbors_cuda.cu", "neighbors_cuda_cell.cu", "backwards.cu"]
+        ["neighbors_cuda.cu", "backwards.cu"]
         if pt.cuda.is_available()
         else []
     )

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -7,5 +7,6 @@ sources = ['neighbors.cpp', 'neighbors_cpu.cpp'] + (['neighbors_cuda.cu', 'neigh
 sources = [os.path.join(src_dir, name) for name in sources]
 cpp_extension.load(name='neighbors', sources=sources, is_python_module=False)
 
-get_neighbor_pairs = pt.ops.neighbors.get_neighbor_pairs
+get_neighbor_pairs_brute = pt.ops.neighbors.get_neighbor_pairs_brute
+get_neighbor_pairs_shared = pt.ops.neighbors.get_neighbor_pairs_shared
 get_neighbor_pairs_cell = pt.ops.neighbors.get_neighbor_pairs_cell

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -11,14 +11,14 @@ def compile_extension():
         else []
     )
     sources = [os.path.join(src_dir, name) for name in sources]
-    cpp_extension.load(name="neighbors", sources=sources, is_python_module=False)
+    cpp_extension.load(name="torchmdnet_neighbors", sources=sources, is_python_module=False, verbose=True)
 
 
 def get_backends():
     compile_extension()
-    get_neighbor_pairs_brute = pt.ops.neighbors.get_neighbor_pairs_brute
-    get_neighbor_pairs_shared = pt.ops.neighbors.get_neighbor_pairs_shared
-    get_neighbor_pairs_cell = pt.ops.neighbors.get_neighbor_pairs_cell
+    get_neighbor_pairs_brute = pt.ops.torchmdnet_neighbors.get_neighbor_pairs_brute
+    get_neighbor_pairs_shared = pt.ops.torchmdnet_neighbors.get_neighbor_pairs_shared
+    get_neighbor_pairs_cell = pt.ops.torchmdnet_neighbors.get_neighbor_pairs_cell
     return {
         "brute": get_neighbor_pairs_brute,
         "cell": get_neighbor_pairs_cell,

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -3,7 +3,7 @@ import torch as pt
 from torch.utils import cpp_extension
 
 src_dir = os.path.dirname(__file__)
-sources = ['neighbors.cpp', 'neighbors_cpu.cpp'] + (['neighbors_cuda.cu', 'neighbors_cuda_cell.cu'] if pt.cuda.is_available() else [])
+sources = ['neighbors.cpp', 'neighbors_cpu.cpp'] + (['neighbors_cuda.cu', 'neighbors_cuda_cell.cu', 'backwards.cu'] if pt.cuda.is_available() else [])
 sources = [os.path.join(src_dir, name) for name in sources]
 cpp_extension.load(name='neighbors', sources=sources, is_python_module=False)
 

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -5,9 +5,14 @@ from torch.utils import cpp_extension
 
 def compile_extension():
     src_dir = os.path.dirname(__file__)
-    sources = ['neighbors.cpp', 'neighbors_cpu.cpp'] + (['neighbors_cuda.cu', 'neighbors_cuda_cell.cu', 'backwards.cu'] if pt.cuda.is_available() else [])
+    sources = ["neighbors.cpp", "neighbors_cpu.cpp"] + (
+        ["neighbors_cuda.cu", "neighbors_cuda_cell.cu", "backwards.cu"]
+        if pt.cuda.is_available()
+        else []
+    )
     sources = [os.path.join(src_dir, name) for name in sources]
-    cpp_extension.load(name='neighbors', sources=sources, is_python_module=False)
+    cpp_extension.load(name="neighbors", sources=sources, is_python_module=False)
+
 
 def get_backends():
     compile_extension()
@@ -15,7 +20,7 @@ def get_backends():
     get_neighbor_pairs_shared = pt.ops.neighbors.get_neighbor_pairs_shared
     get_neighbor_pairs_cell = pt.ops.neighbors.get_neighbor_pairs_cell
     return {
-            "brute": get_neighbor_pairs_brute,
-            "cell": get_neighbor_pairs_cell,
-            "shared": get_neighbor_pairs_shared,
+        "brute": get_neighbor_pairs_brute,
+        "cell": get_neighbor_pairs_cell,
+        "shared": get_neighbor_pairs_shared,
     }

--- a/torchmdnet/neighbors/backwards.cu
+++ b/torchmdnet/neighbors/backwards.cu
@@ -16,9 +16,9 @@ backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2
       return;
     }
     const scalar_t grad_deltas_ = grad_deltas[i_pair][i_comp];
-    // Handle self interaction
     const scalar_t dist = distances[i_pair];
     const scalar_t grad_distances_ = deltas[i_pair][i_comp] / dist * grad_distances[i_pair];
+    // Handle self interaction
     const scalar_t grad =
         (i_dir ? -1 : 1) *
         (i_atom == neighbors[1 - i_dir][i_pair] ? scalar_t(0.0) : (grad_deltas_ + grad_distances_));

--- a/torchmdnet/neighbors/backwards.cu
+++ b/torchmdnet/neighbors/backwards.cu
@@ -10,8 +10,9 @@ backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2
                 const Accessor<scalar_t, 1> grad_distances, Accessor<scalar_t, 2> grad_positions) {
     const int32_t i_pair = blockIdx.x * blockDim.x + threadIdx.x;
     const int32_t num_pairs = neighbors.size(1);
-    if (i_pair >= num_pairs)
+    if (i_pair >= num_pairs){
         return;
+    }
     const int32_t i_dir = blockIdx.y;
     const int32_t i_atom = neighbors[i_dir][i_pair];
     const int32_t i_comp = blockIdx.z;
@@ -29,9 +30,9 @@ backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2
 }
 
 
-tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs) {
-    const Tensor grad_deltas = grad_inputs[1];
-    const Tensor grad_distances = grad_inputs[2];
+tensor_list common_backward(AutogradContext* ctx, const tensor_list &grad_inputs) {
+    const Tensor& grad_deltas = grad_inputs[1];
+    const Tensor& grad_distances = grad_inputs[2];
     const int num_atoms = ctx->saved_data["num_atoms"].toInt();
     const int num_pairs = grad_distances.size(0);
     const int num_threads = 128;
@@ -40,9 +41,9 @@ tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs) {
     const auto stream = getCurrentCUDAStream(grad_distances.get_device());
 
     const tensor_list data = ctx->get_saved_variables();
-    const Tensor neighbors = data[0];
-    const Tensor deltas = data[1];
-    const Tensor distances = data[2];
+    const Tensor& neighbors = data[0];
+    const Tensor& deltas = data[1];
+    const Tensor& distances = data[2];
     const Tensor grad_positions = zeros({num_atoms, 3}, grad_distances.options());
 
     AT_DISPATCH_FLOATING_TYPES(grad_distances.scalar_type(), "getNeighborPairs::backward", [&]() {

--- a/torchmdnet/neighbors/backwards.cu
+++ b/torchmdnet/neighbors/backwards.cu
@@ -1,0 +1,54 @@
+#include "common.cuh"
+
+template <typename scalar_t>
+__global__ void
+backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2> deltas,
+                const Accessor<scalar_t, 2> grad_deltas, const Accessor<scalar_t, 1> distances,
+                const Accessor<scalar_t, 1> grad_distances, Accessor<scalar_t, 2> grad_positions) {
+    const int32_t i_pair = blockIdx.x * blockDim.x + threadIdx.x;
+    const int32_t num_pairs = neighbors.size(1);
+    if (i_pair >= num_pairs)
+        return;
+    const int32_t i_dir = blockIdx.y;
+    const int32_t i_atom = neighbors[i_dir][i_pair];
+    const int32_t i_comp = blockIdx.z;
+    if (i_atom < 0){
+      return;
+    }
+    const scalar_t grad_deltas_ = grad_deltas[i_pair][i_comp];
+    // Handle self interaction
+    const scalar_t dist = distances[i_pair];
+    const scalar_t grad_distances_ = deltas[i_pair][i_comp] / dist * grad_distances[i_pair];
+    const scalar_t grad =
+        (i_dir ? -1 : 1) *
+        (i_atom == neighbors[1 - i_dir][i_pair] ? scalar_t(0.0) : (grad_deltas_ + grad_distances_));
+    atomicAdd(&grad_positions[i_atom][i_comp], grad);
+}
+
+tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs) {
+    const Tensor grad_deltas = grad_inputs[1];
+    const Tensor grad_distances = grad_inputs[2];
+    const int num_atoms = ctx->saved_data["num_atoms"].toInt();
+    const int num_pairs = grad_distances.size(0);
+    const int num_threads = 128;
+    const int num_blocks_x = std::max((num_pairs + num_threads - 1) / num_threads, 1);
+    const dim3 blocks(num_blocks_x, 2, 3);
+    const auto stream = getCurrentCUDAStream(grad_distances.get_device());
+
+    const tensor_list data = ctx->get_saved_variables();
+    const Tensor neighbors = data[0];
+    const Tensor deltas = data[1];
+    const Tensor distances = data[2];
+    const Tensor grad_positions = zeros({num_atoms, 3}, grad_distances.options());
+
+    AT_DISPATCH_FLOATING_TYPES(grad_distances.scalar_type(), "getNeighborPairs::backward", [&]() {
+        const CUDAStreamGuard guard(stream);
+        backward_kernel<<<blocks, num_threads, 0, stream>>>(
+            get_accessor<int32_t, 2>(neighbors), get_accessor<scalar_t, 2>(deltas),
+            get_accessor<scalar_t, 2>(grad_deltas), get_accessor<scalar_t, 1>(distances),
+            get_accessor<scalar_t, 1>(grad_distances), get_accessor<scalar_t, 2>(grad_positions));
+    });
+
+    return {grad_positions, Tensor(), Tensor(), Tensor(), Tensor(),
+            Tensor(),       Tensor(), Tensor(), Tensor(), Tensor()};
+}

--- a/torchmdnet/neighbors/backwards.cu
+++ b/torchmdnet/neighbors/backwards.cu
@@ -28,8 +28,8 @@ backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2
     atomicAdd(&grad_positions[i_atom][i_comp], grad);
 }
 
+
 tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs) {
-    // Common backward pass for all the CUDA neighbor list operations
     const Tensor grad_deltas = grad_inputs[1];
     const Tensor grad_distances = grad_inputs[2];
     const int num_atoms = ctx->saved_data["num_atoms"].toInt();

--- a/torchmdnet/neighbors/backwards.cu
+++ b/torchmdnet/neighbors/backwards.cu
@@ -1,3 +1,6 @@
+/* Raul P. Pelaez 2023. Backwards pass for the CUDA neighbor list operation.
+   Computes the gradient of the positions with respect to the distances and deltas.
+ */
 #include "common.cuh"
 
 template <typename scalar_t>
@@ -12,8 +15,8 @@ backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2
     const int32_t i_dir = blockIdx.y;
     const int32_t i_atom = neighbors[i_dir][i_pair];
     const int32_t i_comp = blockIdx.z;
-    if (i_atom < 0){
-      return;
+    if (i_atom < 0) {
+        return;
     }
     const scalar_t grad_deltas_ = grad_deltas[i_pair][i_comp];
     const scalar_t dist = distances[i_pair];
@@ -26,6 +29,7 @@ backward_kernel(const Accessor<int32_t, 2> neighbors, const Accessor<scalar_t, 2
 }
 
 tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs) {
+    // Common backward pass for all the CUDA neighbor list operations
     const Tensor grad_deltas = grad_inputs[1];
     const Tensor grad_distances = grad_inputs[2];
     const int num_atoms = ctx->saved_data["num_atoms"].toInt();

--- a/torchmdnet/neighbors/common.cuh
+++ b/torchmdnet/neighbors/common.cuh
@@ -93,27 +93,26 @@ template <class scalar_t> struct PairListAccessor {
 
 template <typename scalar_t>
 __device__ void writeAtomPair(PairListAccessor<scalar_t>& list, int i, int j,
-			      scalar3<scalar_t> delta, scalar_t distance, int i_pair) {
-  list.neighbors[0][i_pair] = i;
-  list.neighbors[1][i_pair] = j;
-  list.deltas[i_pair][0] = delta.x;
-  list.deltas[i_pair][1] = delta.y;
-  list.deltas[i_pair][2] = delta.z;
-  list.distances[i_pair] = distance;
+                              scalar3<scalar_t> delta, scalar_t distance, int i_pair) {
+    list.neighbors[0][i_pair] = i;
+    list.neighbors[1][i_pair] = j;
+    list.deltas[i_pair][0] = delta.x;
+    list.deltas[i_pair][1] = delta.y;
+    list.deltas[i_pair][2] = delta.z;
+    list.distances[i_pair] = distance;
 }
 
 template <typename scalar_t>
 __device__ void addAtomPairToList(PairListAccessor<scalar_t>& list, int i, int j,
-                                  scalar3<scalar_t> delta, scalar_t distance,
-                                  bool add_transpose) {
-  const int32_t i_pair = atomicAdd(&list.i_curr_pair[0], add_transpose ? 2 : 1);
-  // Neighbors after the max number of pairs are ignored, although the pair is counted
-  if (i_pair + add_transpose < list.neighbors.size(1)) {
-    writeAtomPair(list, i, j, delta, distance, i_pair);
-    if (add_transpose) {
-      writeAtomPair(list, j, i, {-delta.x, -delta.y, -delta.z}, distance, i_pair + 1);
+                                  scalar3<scalar_t> delta, scalar_t distance, bool add_transpose) {
+    const int32_t i_pair = atomicAdd(&list.i_curr_pair[0], add_transpose ? 2 : 1);
+    // Neighbors after the max number of pairs are ignored, although the pair is counted
+    if (i_pair + add_transpose < list.neighbors.size(1)) {
+        writeAtomPair(list, i, j, delta, distance, i_pair);
+        if (add_transpose) {
+            writeAtomPair(list, j, i, {-delta.x, -delta.y, -delta.z}, distance, i_pair + 1);
+        }
     }
-  }
 }
 
 static void checkInput(const Tensor& positions, const Tensor& batch) {
@@ -164,11 +163,9 @@ namespace triclinic {
 template <typename scalar_t> struct Box {
     scalar_t size[3][3];
     Box(const Tensor& box_vectors) {
-        if (box_vectors.size(0) == 3 && box_vectors.size(1) == 3) {
-            for (int i = 0; i < 3; i++) {
-                for (int j = 0; j < 3; j++) {
-                    size[i][j] = box_vectors[i][j].item<scalar_t>();
-                }
+        for (int i = 0; i < 3; i++) {
+            for (int j = 0; j < 3; j++) {
+                size[i][j] = box_vectors[i][j].item<scalar_t>();
             }
         }
     }

--- a/torchmdnet/neighbors/common.cuh
+++ b/torchmdnet/neighbors/common.cuh
@@ -1,7 +1,8 @@
-#pragma once
+#ifndef NEIGHBORS_COMMON_CUH
+#define NEIGHBORS_COMMON_CUH
+#include <ATen/cuda/CUDAContext.h>
 #include <c10/cuda/CUDAGuard.h>
 #include <c10/cuda/CUDAStream.h>
-#include <ATen/cuda/CUDAContext.h>
 #include <torch/extension.h>
 
 using c10::cuda::CUDAStreamGuard;
@@ -118,3 +119,6 @@ __device__ auto compute_distance(scalar3<scalar_t> pos_i, scalar3<scalar_t> pos_
 }
 
 } // namespace triclinic
+
+tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs);
+#endif

--- a/torchmdnet/neighbors/common.cuh
+++ b/torchmdnet/neighbors/common.cuh
@@ -1,3 +1,5 @@
+/* Raul P. Pelaez 2023. Common utilities for the CUDA neighbor operation.
+ */
 #ifndef NEIGHBORS_COMMON_CUH
 #define NEIGHBORS_COMMON_CUH
 #include <ATen/cuda/CUDAContext.h>
@@ -34,24 +36,14 @@ template <> __device__ __forceinline__ double sqrt_(double x) {
     return ::sqrt(x);
 };
 
-template <typename scalar_t> struct vec4 {
-    using type = void;
-};
-template <> struct vec4<float> {
-    using type = float4;
-};
-template <> struct vec4<double> {
-    using type = double4;
-};
-
-template <typename scalar_t> using scalar4 = typename vec4<scalar_t>::type;
-
 template <typename scalar_t> struct vec3 {
     using type = void;
 };
+
 template <> struct vec3<float> {
     using type = float3;
 };
+
 template <> struct vec3<double> {
     using type = double3;
 };
@@ -59,12 +51,6 @@ template <> struct vec3<double> {
 template <typename scalar_t> using scalar3 = typename vec3<scalar_t>::type;
 
 static void checkInput(const Tensor& positions, const Tensor& batch) {
-    // Batch contains the molecule index for each atom in positions
-    // Neighbors are only calculated within the same molecule
-    // Batch is a 1D tensor of size (N_atoms)
-    // Batch is assumed to be sorted
-    // Batch is assumed to be contiguous
-    // Batch is assumed to be of type torch::kLong
     TORCH_CHECK(positions.dim() == 2, "Expected \"positions\" to have two dimensions");
     TORCH_CHECK(positions.size(0) > 0,
                 "Expected the 1nd dimension size of \"positions\" to be more than 0");
@@ -154,5 +140,9 @@ __device__ auto compute_distance(scalar3<scalar_t> pos_i, scalar3<scalar_t> pos_
 
 } // namespace triclinic
 
+/*
+ * Backward pass for the CUDA neighbor list operation.
+ * Computes the gradient of the positions with respect to the distances and deltas.
+ */
 tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs);
 #endif

--- a/torchmdnet/neighbors/common.cuh
+++ b/torchmdnet/neighbors/common.cuh
@@ -162,10 +162,12 @@ __device__ auto compute_distance(scalar3<scalar_t> pos_i, scalar3<scalar_t> pos_
 namespace triclinic {
 template <typename scalar_t> struct Box {
     scalar_t size[3][3];
-    Box(const Tensor& box_vectors) {
-        for (int i = 0; i < 3; i++) {
-            for (int j = 0; j < 3; j++) {
-                size[i][j] = box_vectors[i][j].item<scalar_t>();
+    Box(const Tensor& box_vectors, bool use_periodic) {
+        if (use_periodic) {
+            for (int i = 0; i < 3; i++) {
+                for (int j = 0; j < 3; j++) {
+                    size[i][j] = box_vectors[i][j].item<scalar_t>();
+                }
             }
         }
     }

--- a/torchmdnet/neighbors/common.cuh
+++ b/torchmdnet/neighbors/common.cuh
@@ -1,0 +1,120 @@
+#pragma once
+#include <c10/cuda/CUDAGuard.h>
+#include <c10/cuda/CUDAStream.h>
+#include <ATen/cuda/CUDAContext.h>
+#include <torch/extension.h>
+
+using c10::cuda::CUDAStreamGuard;
+using c10::cuda::getCurrentCUDAStream;
+using torch::empty;
+using torch::full;
+using torch::kInt32;
+using torch::Scalar;
+using torch::Tensor;
+using torch::TensorOptions;
+using torch::zeros;
+using torch::autograd::AutogradContext;
+using torch::autograd::Function;
+using torch::autograd::tensor_list;
+
+template <typename scalar_t, int num_dims>
+using Accessor = torch::PackedTensorAccessor32<scalar_t, num_dims, torch::RestrictPtrTraits>;
+
+template <typename scalar_t, int num_dims>
+inline Accessor<scalar_t, num_dims> get_accessor(const Tensor& tensor) {
+    return tensor.packed_accessor32<scalar_t, num_dims, torch::RestrictPtrTraits>();
+};
+
+template <typename scalar_t> __device__ __forceinline__ scalar_t sqrt_(scalar_t x){};
+template <> __device__ __forceinline__ float sqrt_(float x) {
+    return ::sqrtf(x);
+};
+template <> __device__ __forceinline__ double sqrt_(double x) {
+    return ::sqrt(x);
+};
+
+template <typename scalar_t> struct vec4 {
+    using type = void;
+};
+template <> struct vec4<float> {
+    using type = float4;
+};
+template <> struct vec4<double> {
+    using type = double4;
+};
+
+template <typename scalar_t> using scalar4 = typename vec4<scalar_t>::type;
+
+template <typename scalar_t> struct vec3 {
+    using type = void;
+};
+template <> struct vec3<float> {
+    using type = float3;
+};
+template <> struct vec3<double> {
+    using type = double3;
+};
+
+template <typename scalar_t> using scalar3 = typename vec3<scalar_t>::type;
+
+namespace rect {
+
+/*
+ * @brief Takes a point to the unit cell in the range [-0.5, 0.5]*box_size using Minimum Image
+ * Convention
+ * @param p The point position
+ * @param box_size The box size
+ * @return The point in the unit cell
+ */
+template <typename scalar_t>
+__device__ auto apply_pbc(scalar3<scalar_t> p, scalar3<scalar_t> box_size) {
+    p.x = p.x - floorf(p.x / box_size.x + scalar_t(0.5)) * box_size.x;
+    p.y = p.y - floorf(p.y / box_size.y + scalar_t(0.5)) * box_size.y;
+    p.z = p.z - floorf(p.z / box_size.z + scalar_t(0.5)) * box_size.z;
+    return p;
+}
+
+template <typename scalar_t>
+__device__ auto compute_distance(scalar3<scalar_t> pos_i, scalar3<scalar_t> pos_j,
+                                 bool use_periodic, scalar3<scalar_t> box_size) {
+    scalar3<scalar_t> delta = {pos_i.x - pos_j.x, pos_i.y - pos_j.y, pos_i.z - pos_j.z};
+    if (use_periodic) {
+        delta = apply_pbc<scalar_t>(delta, box_size);
+    }
+    return delta;
+}
+
+} // namespace rect
+namespace triclinic {
+/*
+ * @brief Takes a point to the unit cell using Minimum Image
+ * Convention
+ * @param p The point position
+ * @param box_vectors The box vectors (3x3 matrix)
+ * @return The point in the unit cell
+ */
+template <typename scalar_t>
+__device__ auto apply_pbc(scalar3<scalar_t> delta, const Accessor<scalar_t, 2> box_vectors) {
+    scalar_t scale3 = round(delta.z / box_vectors[2][2]);
+    delta.x -= scale3 * box_vectors[2][0];
+    delta.y -= scale3 * box_vectors[2][1];
+    delta.z -= scale3 * box_vectors[2][2];
+    scalar_t scale2 = round(delta.y / box_vectors[1][1]);
+    delta.x -= scale2 * box_vectors[1][0];
+    delta.y -= scale2 * box_vectors[1][1];
+    scalar_t scale1 = round(delta.x / box_vectors[0][0]);
+    delta.x -= scale1 * box_vectors[0][0];
+    return delta;
+}
+
+template <typename scalar_t>
+__device__ auto compute_distance(scalar3<scalar_t> pos_i, scalar3<scalar_t> pos_j,
+                                 bool use_periodic, const Accessor<scalar_t, 2> box_vectors) {
+    scalar3<scalar_t> delta = {pos_i.x - pos_j.x, pos_i.y - pos_j.y, pos_i.z - pos_j.z};
+    if (use_periodic) {
+        delta = apply_pbc(delta, box_vectors);
+    }
+    return delta;
+}
+
+} // namespace triclinic

--- a/torchmdnet/neighbors/common.cuh
+++ b/torchmdnet/neighbors/common.cuh
@@ -144,5 +144,5 @@ __device__ auto compute_distance(scalar3<scalar_t> pos_i, scalar3<scalar_t> pos_
  * Backward pass for the CUDA neighbor list operation.
  * Computes the gradient of the positions with respect to the distances and deltas.
  */
-tensor_list common_backward(AutogradContext* ctx, tensor_list grad_inputs);
+tensor_list common_backward(AutogradContext* ctx, const tensor_list &grad_inputs);
 #endif

--- a/torchmdnet/neighbors/neighbors.cpp
+++ b/torchmdnet/neighbors/neighbors.cpp
@@ -1,6 +1,7 @@
 #include <torch/extension.h>
 
 TORCH_LIBRARY(neighbors, m) {
-    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
-    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs_brute(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");
+    m.def("get_neighbor_pairs_shared(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");
+    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");
 }

--- a/torchmdnet/neighbors/neighbors.cpp
+++ b/torchmdnet/neighbors/neighbors.cpp
@@ -1,6 +1,6 @@
 #include <torch/extension.h>
 
-TORCH_LIBRARY(neighbors, m) {
+TORCH_LIBRARY(torchmdnet_neighbors, m) {
     m.def("get_neighbor_pairs_brute(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");
     m.def("get_neighbor_pairs_shared(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");
     m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");

--- a/torchmdnet/neighbors/neighbors.cpp
+++ b/torchmdnet/neighbors/neighbors.cpp
@@ -1,6 +1,6 @@
 #include <torch/extension.h>
 
 TORCH_LIBRARY(neighbors, m) {
-    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
-    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
 }

--- a/torchmdnet/neighbors/neighbors.cpp
+++ b/torchmdnet/neighbors/neighbors.cpp
@@ -1,6 +1,6 @@
 #include <torch/extension.h>
 
 TORCH_LIBRARY(neighbors, m) {
-    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
-    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
 }

--- a/torchmdnet/neighbors/neighbors.cpp
+++ b/torchmdnet/neighbors/neighbors.cpp
@@ -1,6 +1,6 @@
 #include <torch/extension.h>
 
 TORCH_LIBRARY(neighbors, m) {
-    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff, Scalar max_num_pairs, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
-    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_size,Scalar cutoff, Scalar max_num_pairs, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
+    m.def("get_neighbor_pairs_cell(Tensor positions, Tensor batch, Tensor box_size, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool check_errors) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs)");
 }

--- a/torchmdnet/neighbors/neighbors_cpu.cpp
+++ b/torchmdnet/neighbors/neighbors_cpu.cpp
@@ -89,7 +89,7 @@ forward(const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
     return {neighbors, deltas, distances, num_pairs_found};
 }
 
-TORCH_LIBRARY_IMPL(neighbors, CPU, m) {
+TORCH_LIBRARY_IMPL(torchmdnet_neighbors, CPU, m) {
     m.impl("get_neighbor_pairs_brute", &forward);
     m.impl("get_neighbor_pairs_shared", &forward);
     m.impl("get_neighbor_pairs_cell", &forward);

--- a/torchmdnet/neighbors/neighbors_cpu.cpp
+++ b/torchmdnet/neighbors/neighbors_cpu.cpp
@@ -2,25 +2,28 @@
 #include <tuple>
 
 using std::tuple;
-using torch::div;
-using torch::full;
-using torch::index_select;
-using torch::indexing::Slice;
 using torch::arange;
+using torch::div;
 using torch::frobenius_norm;
-using torch::kInt32;
-using torch::Scalar;
+using torch::full;
 using torch::hstack;
-using torch::vstack;
-using torch::Tensor;
+using torch::index_select;
+using torch::kInt32;
 using torch::outer;
 using torch::round;
+using torch::Scalar;
+using torch::Tensor;
+using torch::vstack;
+using torch::indexing::Slice;
 
-static tuple<Tensor, Tensor, Tensor> forward(const Tensor& positions, const Tensor& batch, const Tensor &box_size,
-					     const Scalar& cutoff_lower, const Scalar& cutoff_upper,
-                                             const Scalar& max_num_pairs, bool loop, bool checkErrors) {
+static tuple<Tensor, Tensor, Tensor> forward(const Tensor& positions, const Tensor& batch,
+                                             const Tensor& box_size, const Scalar& cutoff_lower,
+                                             const Scalar& cutoff_upper,
+                                             const Scalar& max_num_pairs, bool loop,
+                                             bool include_transpose, bool checkErrors) {
     TORCH_CHECK(positions.dim() == 2, "Expected \"positions\" to have two dimensions");
-    TORCH_CHECK(positions.size(0) > 0, "Expected the 1nd dimension size of \"positions\" to be more than 0");
+    TORCH_CHECK(positions.size(0) > 0,
+                "Expected the 1nd dimension size of \"positions\" to be more than 0");
     TORCH_CHECK(positions.size(1) == 3, "Expected the 2nd dimension size of \"positions\" to be 3");
     TORCH_CHECK(positions.is_contiguous(), "Expected \"positions\" to be contiguous");
 
@@ -41,12 +44,14 @@ static tuple<Tensor, Tensor, Tensor> forward(const Tensor& positions, const Tens
         TORCH_CHECK(v[0][0] >= 2 * c, "Invalid box vectors: box_vectors[0][0] < 2*cutoff");
         TORCH_CHECK(v[1][1] >= 2 * c, "Invalid box vectors: box_vectors[1][1] < 2*cutoff");
         TORCH_CHECK(v[2][2] >= 2 * c, "Invalid box vectors: box_vectors[2][2] < 2*cutoff");
-        TORCH_CHECK(v[0][0] >= 2 * v[1][0], "Invalid box vectors: box_vectors[0][0] < 2*box_vectors[1][0]");
-        TORCH_CHECK(v[0][0] >= 2 * v[2][0], "Invalid box vectors: box_vectors[0][0] < 2*box_vectors[1][0]");
-        TORCH_CHECK(v[1][1] >= 2 * v[2][1], "Invalid box vectors: box_vectors[1][1] < 2*box_vectors[2][1]");
+        TORCH_CHECK(v[0][0] >= 2 * v[1][0],
+                    "Invalid box vectors: box_vectors[0][0] < 2*box_vectors[1][0]");
+        TORCH_CHECK(v[0][0] >= 2 * v[2][0],
+                    "Invalid box vectors: box_vectors[0][0] < 2*box_vectors[1][0]");
+        TORCH_CHECK(v[1][1] >= 2 * v[2][1],
+                    "Invalid box vectors: box_vectors[1][1] < 2*box_vectors[2][1]");
     }
-    TORCH_CHECK(max_num_pairs.toLong() > 0,
-                "Expected \"max_num_neighbors\" to be positive");
+    TORCH_CHECK(max_num_pairs.toLong() > 0, "Expected \"max_num_neighbors\" to be positive");
     const int n_atoms = positions.size(0);
     const int n_batches = batch[n_atoms - 1].item<int>() + 1;
     int current_offset = 0;
@@ -55,43 +60,49 @@ static tuple<Tensor, Tensor, Tensor> forward(const Tensor& positions, const Tens
     Tensor neighbors = torch::empty({0}, positions.options().dtype(kInt32));
     Tensor distances = torch::empty({0}, positions.options());
     Tensor deltas = torch::empty({0}, positions.options());
-    for(int i = 0; i < n_batches; i++){
-      batch_i.clear();
-      for(int j = current_offset; j < n_atoms; j++){
-	if(batch[j].item<int>() == i){
-	  batch_i.push_back(j);
-	}
-	else{
-	  break;
-	}
-      }
-      const int n_atoms_i = batch_i.size();
-      Tensor positions_i = index_select(positions, 0, torch::tensor(batch_i, kInt32));
-      Tensor indices_i = arange(0, n_atoms_i * (n_atoms_i - 1) / 2, positions.options().dtype(kInt32));
-      Tensor rows_i = (((8 * indices_i + 1).sqrt() + 1) / 2).floor().to(kInt32);
-      rows_i -= (rows_i * (rows_i - 1) > 2 * indices_i).to(kInt32);
-      Tensor columns_i = indices_i - div(rows_i * (rows_i - 1), 2, "floor");
-      Tensor neighbors_i = vstack({rows_i, columns_i});
-      Tensor deltas_i = index_select(positions_i, 0, rows_i) - index_select(positions_i, 0, columns_i);
-      Tensor distances_i = frobenius_norm(deltas_i, 1);
-      const Tensor mask_upper = distances_i <= cutoff_upper;
-      const Tensor mask_lower = distances_i >= cutoff_lower;
-      const Tensor mask = mask_upper*mask_lower;
-      neighbors_i = neighbors_i.index({Slice(), mask}) + current_offset;
-      //Add the transposed pairs
-      neighbors_i = torch::hstack({neighbors_i, torch::stack({neighbors_i[1], neighbors_i[0]})});
-      //Add self interaction using batch_i
-      if(loop){
-	const Tensor batch_i_tensor = torch::tensor(batch_i, kInt32);
-	neighbors_i = torch::hstack({neighbors_i, torch::stack({batch_i_tensor, batch_i_tensor})});
-      }
-      n_pairs += neighbors_i.size(1);
-      TORCH_CHECK(n_pairs >= 0, "The maximum number of pairs has been exceed! Increase \"max_num_neighbors\"");
-      neighbors = torch::hstack({neighbors, neighbors_i});
-      current_offset += n_atoms_i;
+    for (int i = 0; i < n_batches; i++) {
+        batch_i.clear();
+        for (int j = current_offset; j < n_atoms; j++) {
+            if (batch[j].item<int>() == i) {
+                batch_i.push_back(j);
+            } else {
+                break;
+            }
+        }
+        const int n_atoms_i = batch_i.size();
+        Tensor positions_i = index_select(positions, 0, torch::tensor(batch_i, kInt32));
+        Tensor indices_i =
+            arange(0, n_atoms_i * (n_atoms_i - 1) / 2, positions.options().dtype(kInt32));
+        Tensor rows_i = (((8 * indices_i + 1).sqrt() + 1) / 2).floor().to(kInt32);
+        rows_i -= (rows_i * (rows_i - 1) > 2 * indices_i).to(kInt32);
+        Tensor columns_i = indices_i - div(rows_i * (rows_i - 1), 2, "floor");
+        Tensor neighbors_i = vstack({rows_i, columns_i});
+        Tensor deltas_i =
+            index_select(positions_i, 0, rows_i) - index_select(positions_i, 0, columns_i);
+        Tensor distances_i = frobenius_norm(deltas_i, 1);
+        const Tensor mask_upper = distances_i <= cutoff_upper;
+        const Tensor mask_lower = distances_i >= cutoff_lower;
+        const Tensor mask = mask_upper * mask_lower;
+        neighbors_i = neighbors_i.index({Slice(), mask}) + current_offset;
+        // Add the transposed pairs
+        if (include_transpose) {
+            neighbors_i =
+                torch::hstack({neighbors_i, torch::stack({neighbors_i[1], neighbors_i[0]})});
+        }
+        // Add self interaction using batch_i
+        if (loop) {
+            const Tensor batch_i_tensor = torch::tensor(batch_i, kInt32);
+            neighbors_i =
+                torch::hstack({neighbors_i, torch::stack({batch_i_tensor, batch_i_tensor})});
+        }
+        n_pairs += neighbors_i.size(1);
+        TORCH_CHECK(n_pairs >= 0,
+                    "The maximum number of pairs has been exceed! Increase \"max_num_neighbors\"");
+        neighbors = torch::hstack({neighbors, neighbors_i});
+        current_offset += n_atoms_i;
     }
-    if(n_batches > 1){
-      neighbors = torch::cat(neighbors,0).to(kInt32);
+    if (n_batches > 1) {
+        neighbors = torch::cat(neighbors, 0).to(kInt32);
     }
     deltas = index_select(positions, 0, neighbors[0]) - index_select(positions, 0, neighbors[1]);
     distances = frobenius_norm(deltas, 1);

--- a/torchmdnet/neighbors/neighbors_cpu.cpp
+++ b/torchmdnet/neighbors/neighbors_cpu.cpp
@@ -78,6 +78,8 @@ static tuple<Tensor, Tensor, Tensor> forward(const Tensor& positions, const Tens
       const Tensor mask_lower = distances_i >= cutoff_lower;
       const Tensor mask = mask_upper*mask_lower;
       neighbors_i = neighbors_i.index({Slice(), mask}) + current_offset;
+      //Add the transposed pairs
+      neighbors_i = torch::hstack({neighbors_i, torch::stack({neighbors_i[1], neighbors_i[0]})});
       //Add self interaction using batch_i
       if(loop){
 	const Tensor batch_i_tensor = torch::tensor(batch_i, kInt32);

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -204,9 +204,6 @@ public:
                             std::to_string(max_num_pairs_),
                         " but found " + std::to_string(num_found_pairs));
         }
-        neighbors.resize_({2, i_curr_pair[0].item<int>()});
-        deltas.resize_({i_curr_pair[0].item<int>(), 3});
-        distances.resize_(i_curr_pair[0].item<int>());
         ctx->save_for_backward({neighbors, deltas, distances});
         ctx->saved_data["num_atoms"] = num_atoms;
         return {neighbors, deltas, distances};

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -237,7 +237,7 @@ public:
         return {neighbors, deltas, distances, i_curr_pair};
     }
 
-    static tensor_list backward(AutogradContext* ctx, tensor_list grad_inputs) {
+    static tensor_list backward(AutogradContext* ctx, const tensor_list &grad_inputs) {
         return common_backward(ctx, grad_inputs);
     }
 };

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -2,11 +2,12 @@
    Connection between the neighbor CUDA implementations and the torch extension.
    See neighbors.cpp for the definition of the torch extension functions.
  */
+#include <torch/extension.h>
 #include "neighbors_cuda_brute.cuh"
 #include "neighbors_cuda_cell.cuh"
 #include "neighbors_cuda_shared.cuh"
 
-TORCH_LIBRARY_IMPL(neighbors, AutogradCUDA, m) {
+TORCH_LIBRARY_IMPL(torchmdnet_neighbors, AutogradCUDA, m) {
     m.impl("get_neighbor_pairs_brute",
            [](const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
               bool use_periodic, const Scalar& cutoff_lower, const Scalar& cutoff_upper,

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -61,15 +61,22 @@ __global__ void forward_kernel(const int64_t num_all_pairs, const Accessor<scala
         scalar_t delta_z = positions[row][2] - positions[column][2];
         const scalar_t distance2 = delta_x * delta_x + delta_y * delta_y + delta_z * delta_z;
         if (distance2 <= cutoff_upper2 && distance2 >= cutoff_lower2) {
-            const int32_t i_pair = atomicAdd(&i_curr_pair[0], 1);
+            const int32_t i_pair = atomicAdd(&i_curr_pair[0], 2);
             // We handle too many neighbors outside of the kernel
             if (i_pair < neighbors.size(1)) {
+	      const scalar_t r2 = sqrt_(distance2);
                 neighbors[0][i_pair] = row;
                 neighbors[1][i_pair] = column;
                 deltas[i_pair][0] = delta_x;
                 deltas[i_pair][1] = delta_y;
                 deltas[i_pair][2] = delta_z;
-                distances[i_pair] = sqrt_(distance2);
+                distances[i_pair] = r2;
+		neighbors[0][i_pair+1] = column;
+                neighbors[1][i_pair+1] = row;
+                deltas[i_pair+1][0] = -delta_x;
+                deltas[i_pair+1][1] = -delta_y;
+                deltas[i_pair+1][2] = -delta_z;
+                distances[i_pair+1] = r2;
             }
         }
     }

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -45,7 +45,7 @@ __device__ int32_t get_row(int index) {
 
 template <typename scalar_t>
 __global__ void forward_kernel(const int64_t num_all_pairs, const Accessor<scalar_t, 2> positions,
-                               const Accessor<int32_t, 1> batch, scalar_t cutoff_lower2,
+                               const Accessor<int64_t, 1> batch, scalar_t cutoff_lower2,
                                scalar_t cutoff_upper2, bool loop, Accessor<int32_t, 1> i_curr_pair,
                                Accessor<int32_t, 2> neighbors, Accessor<scalar_t, 2> deltas,
                                Accessor<scalar_t, 1> distances) {
@@ -154,7 +154,7 @@ static void checkInput(const Tensor& positions, const Tensor& batch) {
                 "Expected the 1st dimension size of \"batch\" to be the same as the 1st dimension "
                 "size of \"positions\"");
     TORCH_CHECK(batch.is_contiguous(), "Expected \"batch\" to be contiguous");
-    TORCH_CHECK(batch.dtype() == torch::kInt32, "Expected \"batch\" to have torch::kInt32 dtype");
+    TORCH_CHECK(batch.dtype() == torch::kInt64, "Expected \"batch\" to be of type torch::kLong");
 }
 
 class Autograd : public Function<Autograd> {
@@ -186,7 +186,7 @@ public:
                     TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");
                     forward_kernel<<<num_blocks, num_threads, 0, stream>>>(
                         num_all_pairs, get_accessor<scalar_t, 2>(positions),
-                        get_accessor<int32_t, 1>(batch), cutoff_lower_ * cutoff_lower_,
+                        get_accessor<int64_t, 1>(batch), cutoff_lower_ * cutoff_lower_,
                         cutoff_upper_ * cutoff_upper_, loop, get_accessor<int32_t, 1>(i_curr_pair),
                         get_accessor<int32_t, 2>(neighbors), get_accessor<scalar_t, 2>(deltas),
                         get_accessor<scalar_t, 1>(distances));

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -167,6 +167,10 @@ public:
         }
         TORCH_CHECK(box_vectors.device() == torch::kCPU, "Expected \"box_vectors\" to be on CPU");
         const int num_atoms = positions.size(0);
+	if(num_atoms > 32768){
+	  //The brute force method runs into integer overflow for num_atoms > 32768
+	  strat = strategy::shared;
+	}
         const int num_pairs = max_num_pairs_;
         const TensorOptions options = positions.options();
         const auto stream = getCurrentCUDAStream(positions.get_device());

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -1,264 +1,45 @@
-#include "common.cuh"
-#include <algorithm>
-#include <torch/extension.h>
-
-__device__ uint32_t get_row(uint32_t index) {
-    uint32_t row = floor((sqrtf(8 * index + 1) + 1) / 2);
-    if (row * (row - 1) > 2 * index)
-        row--;
-    return row;
-}
-
-template <typename scalar_t>
-__global__ void forward_kernel_brute(uint32_t num_all_pairs, const Accessor<scalar_t, 2> positions,
-                                     const Accessor<int64_t, 1> batch, scalar_t cutoff_lower2,
-                                     scalar_t cutoff_upper2, bool loop, bool include_transpose,
-                                     Accessor<int32_t, 1> i_curr_pair,
-                                     Accessor<int32_t, 2> neighbors, Accessor<scalar_t, 2> deltas,
-                                     Accessor<scalar_t, 1> distances, bool use_periodic,
-                                     triclinic::Box<scalar_t> box) {
-    const uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
-    if (index >= num_all_pairs)
-        return;
-    const uint32_t row = get_row(index);
-    const uint32_t column = (index - row * (row - 1) / 2);
-    if (batch[row] == batch[column]) {
-        const scalar3<scalar_t> pos_i{positions[row][0], positions[row][1], positions[row][2]};
-        const scalar3<scalar_t> pos_j{positions[column][0], positions[column][1],
-                                      positions[column][2]};
-        const auto delta = triclinic::compute_distance(pos_i, pos_j, use_periodic, box);
-        const scalar_t distance2 = delta.x * delta.x + delta.y * delta.y + delta.z * delta.z;
-        if (distance2 < cutoff_upper2 && distance2 >= cutoff_lower2) {
-            const int32_t i_pair = atomicAdd(&i_curr_pair[0], include_transpose ? 2 : 1);
-            // We handle too many neighbors outside of the kernel
-            if (i_pair + include_transpose < neighbors.size(1)) {
-                const scalar_t r2 = sqrt_(distance2);
-                neighbors[0][i_pair] = row;
-                neighbors[1][i_pair] = column;
-                deltas[i_pair][0] = delta.x;
-                deltas[i_pair][1] = delta.y;
-                deltas[i_pair][2] = delta.z;
-                distances[i_pair] = r2;
-                if (include_transpose) {
-                    neighbors[0][i_pair + 1] = column;
-                    neighbors[1][i_pair + 1] = row;
-                    deltas[i_pair + 1][0] = -delta.x;
-                    deltas[i_pair + 1][1] = -delta.y;
-                    deltas[i_pair + 1][2] = -delta.z;
-                    distances[i_pair + 1] = r2;
-                }
-            }
-        }
-    }
-}
-
-template <typename scalar_t>
-__global__ void add_self_kernel(const int num_atoms, Accessor<scalar_t, 2> positions,
-                                Accessor<int32_t, 1> i_curr_pair, Accessor<int32_t, 2> neighbors,
-                                Accessor<scalar_t, 2> deltas, Accessor<scalar_t, 1> distances) {
-    const int32_t i_atom = blockIdx.x * blockDim.x + threadIdx.x;
-    if (i_atom >= num_atoms)
-        return;
-    const int32_t i_pair = atomicAdd(&i_curr_pair[0], 1);
-    if (i_pair < neighbors.size(1)) {
-        neighbors[0][i_pair] = i_atom;
-        neighbors[1][i_pair] = i_atom;
-        deltas[i_pair][0] = 0;
-        deltas[i_pair][1] = 0;
-        deltas[i_pair][2] = 0;
-        distances[i_pair] = 0;
-    }
-}
-
-template <int BLOCKSIZE, typename scalar_t>
-__global__ void forward_kernel_shared(uint32_t num_atoms, const Accessor<scalar_t, 2> positions,
-                                      const Accessor<int64_t, 1> batch, scalar_t cutoff_lower2,
-                                      scalar_t cutoff_upper2, bool loop, bool include_transpose,
-                                      Accessor<int32_t, 1> i_curr_pair,
-                                      Accessor<int32_t, 2> neighbors, Accessor<scalar_t, 2> deltas,
-                                      Accessor<scalar_t, 1> distances, int32_t num_tiles,
-                                      bool use_periodic, triclinic::Box<scalar_t> box) {
-    // A thread per atom
-    const int id = blockIdx.x * blockDim.x + threadIdx.x;
-    // All threads must pass through __syncthreads,
-    // but when N is not a multiple of 32 some threads are assigned a particle i>N.
-    // This threads cant return, so they are masked to not do any work
-    const bool active = id < num_atoms;
-    __shared__ scalar3<scalar_t> sh_pos[BLOCKSIZE];
-    __shared__ int64_t sh_batch[BLOCKSIZE];
-    scalar3<scalar_t> pos_i;
-    int64_t batch_i;
-    if (active) {
-        pos_i = {positions[id][0], positions[id][1], positions[id][2]};
-        batch_i = batch[id];
-    }
-    // Distribute the N particles in a group of tiles. Storing in each tile blockDim.x values in
-    // shared memory. This way all threads are accesing the same memory addresses at the same time
-    for (int tile = 0; tile < num_tiles; tile++) {
-        // Load this tiles particles values to shared memory
-        const int i_load = tile * blockDim.x + threadIdx.x;
-        if (i_load < num_atoms) { // Even if im not active, my thread may load a value each tile to
-            // shared memory.
-            sh_pos[threadIdx.x] = {positions[i_load][0], positions[i_load][1],
-                                   positions[i_load][2]};
-            sh_batch[threadIdx.x] = batch[i_load];
-        }
-        // Wait for all threads to arrive
-        __syncthreads();
-        // Go through all the particles in the current tile
-#pragma unroll 8
-        for (int counter = 0; counter < blockDim.x; counter++) {
-            if (!active)
-                break; // An out of bounds thread must be masked
-            const int cur_j = tile * blockDim.x + counter;
-            const bool testPair = cur_j < num_atoms and (cur_j < id or (loop and cur_j == id));
-            if (testPair) {
-                const auto batch_j = sh_batch[counter];
-                if (batch_i == batch_j) {
-                    const auto pos_j = sh_pos[counter];
-                    const auto delta = triclinic::compute_distance(pos_i, pos_j, use_periodic, box);
-                    const scalar_t distance2 =
-                        delta.x * delta.x + delta.y * delta.y + delta.z * delta.z;
-                    if (distance2 < cutoff_upper2 && distance2 >= cutoff_lower2) {
-                        const bool requires_transpose = include_transpose && !(cur_j == id);
-                        const int32_t i_pair =
-                            atomicAdd(&i_curr_pair[0], requires_transpose ? 2 : 1);
-                        if (i_pair + requires_transpose < neighbors.size(1)) {
-                            const auto distance = sqrt_(distance2);
-                            neighbors[0][i_pair] = id;
-                            neighbors[1][i_pair] = cur_j;
-                            deltas[i_pair][0] = delta.x;
-                            deltas[i_pair][1] = delta.y;
-                            deltas[i_pair][2] = delta.z;
-                            distances[i_pair] = distance;
-                            if (requires_transpose) {
-                                neighbors[0][i_pair + 1] = cur_j;
-                                neighbors[1][i_pair + 1] = id;
-                                deltas[i_pair + 1][0] = -delta.x;
-                                deltas[i_pair + 1][1] = -delta.y;
-                                deltas[i_pair + 1][2] = -delta.z;
-                                distances[i_pair + 1] = distance;
-                            }
-                        }
-                    }
-                }
-            }
-        }
-        __syncthreads();
-    }
-}
-
-enum class strategy { brute, shared };
-
-class Autograd : public Function<Autograd> {
-public:
-    static tensor_list forward(AutogradContext* ctx, const Tensor& positions, const Tensor& batch,
-                               const Scalar& cutoff_lower, const Scalar& cutoff_upper,
-                               const Tensor& box_vectors, bool use_periodic,
-                               const Scalar& max_num_pairs, bool loop, bool include_transpose,
-                               strategy strat) {
-        checkInput(positions, batch);
-        const auto max_num_pairs_ = max_num_pairs.toLong();
-        TORCH_CHECK(max_num_pairs_ > 0, "Expected \"max_num_neighbors\" to be positive");
-        if (use_periodic) {
-            TORCH_CHECK(box_vectors.dim() == 2, "Expected \"box_vectors\" to have two dimensions");
-            TORCH_CHECK(box_vectors.size(0) == 3 && box_vectors.size(1) == 3,
-                        "Expected \"box_vectors\" to have shape (3, 3)");
-        }
-        TORCH_CHECK(box_vectors.device() == torch::kCPU, "Expected \"box_vectors\" to be on CPU");
-        const int num_atoms = positions.size(0);
-	if(num_atoms > 32768){
-	  //The brute force method runs into integer overflow for num_atoms > 32768
-	  strat = strategy::shared;
-	}
-        const int num_pairs = max_num_pairs_;
-        const TensorOptions options = positions.options();
-        const auto stream = getCurrentCUDAStream(positions.get_device());
-        const Tensor neighbors = full({2, num_pairs}, -1, options.dtype(kInt32));
-        const Tensor deltas = empty({num_pairs, 3}, options);
-        const Tensor distances = full(num_pairs, 0, options);
-        const Tensor i_curr_pair = zeros(1, options.dtype(kInt32));
-        {
-            const CUDAStreamGuard guard(stream);
-            const int32_t num_atoms = positions.size(0);
-            if (strat == strategy::brute) {
-                const uint64_t num_all_pairs = num_atoms * (num_atoms - 1ul) / 2ul;
-                const uint64_t num_threads = 128;
-                const uint64_t num_blocks =
-                    std::max((num_all_pairs + num_threads - 1ul) / num_threads, 1ul);
-                AT_DISPATCH_FLOATING_TYPES(
-                    positions.scalar_type(), "get_neighbor_pairs_forward", [&]() {
-                        triclinic::Box<scalar_t> box(box_vectors);
-                        const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
-                        const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
-                        TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");
-                        forward_kernel_brute<<<num_blocks, num_threads, 0, stream>>>(
-                            num_all_pairs, get_accessor<scalar_t, 2>(positions),
-                            get_accessor<int64_t, 1>(batch), cutoff_lower_ * cutoff_lower_,
-                            cutoff_upper_ * cutoff_upper_, loop, include_transpose,
-                            get_accessor<int32_t, 1>(i_curr_pair),
-                            get_accessor<int32_t, 2>(neighbors), get_accessor<scalar_t, 2>(deltas),
-                            get_accessor<scalar_t, 1>(distances), use_periodic, box);
-                        if (loop) {
-                            const uint64_t num_threads = 128;
-                            const uint64_t num_blocks =
-                                std::max((num_atoms + num_threads - 1ul) / num_threads, 1ul);
-                            add_self_kernel<<<num_blocks, num_threads, 0, stream>>>(
-                                num_atoms, get_accessor<scalar_t, 2>(positions),
-                                get_accessor<int32_t, 1>(i_curr_pair),
-                                get_accessor<int32_t, 2>(neighbors),
-                                get_accessor<scalar_t, 2>(deltas),
-                                get_accessor<scalar_t, 1>(distances));
-                        }
-                    });
-            } else if (strat == strategy::shared) {
-                AT_DISPATCH_FLOATING_TYPES(
-                    positions.scalar_type(), "get_neighbor_pairs_shared_forward", [&]() {
-                        const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
-                        const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
-                        triclinic::Box<scalar_t> box(box_vectors);
-                        TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");
-                        constexpr int BLOCKSIZE = 64;
-                        const int num_blocks = std::max((num_atoms + BLOCKSIZE - 1) / BLOCKSIZE, 1);
-                        const int num_threads = BLOCKSIZE;
-                        const int num_tiles = num_blocks;
-                        forward_kernel_shared<BLOCKSIZE><<<num_blocks, num_threads, 0, stream>>>(
-                            num_atoms, get_accessor<scalar_t, 2>(positions),
-                            get_accessor<int64_t, 1>(batch), cutoff_lower_ * cutoff_lower_,
-                            cutoff_upper_ * cutoff_upper_, loop, include_transpose,
-                            get_accessor<int32_t, 1>(i_curr_pair),
-                            get_accessor<int32_t, 2>(neighbors), get_accessor<scalar_t, 2>(deltas),
-                            get_accessor<scalar_t, 1>(distances), num_tiles, use_periodic, box);
-                    });
-            }
-        }
-        ctx->save_for_backward({neighbors, deltas, distances});
-        ctx->saved_data["num_atoms"] = num_atoms;
-        return {neighbors, deltas, distances, i_curr_pair};
-    }
-
-    static tensor_list backward(AutogradContext* ctx, const tensor_list &grad_inputs) {
-        return common_backward(ctx, grad_inputs);
-    }
-};
+/* Raul P. Pelaez 2023
+   Connection between the neighbor CUDA implementations and the torch extension.
+   See neighbors.cpp for the definition of the torch extension functions.
+ */
+#include "neighbors_cuda_brute.cuh"
+#include "neighbors_cuda_cell.cuh"
+#include "neighbors_cuda_shared.cuh"
 
 TORCH_LIBRARY_IMPL(neighbors, AutogradCUDA, m) {
     m.impl("get_neighbor_pairs_brute",
            [](const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
               bool use_periodic, const Scalar& cutoff_lower, const Scalar& cutoff_upper,
               const Scalar& max_num_pairs, bool loop, bool include_transpose) {
-               const tensor_list results = Autograd::apply(
-                   positions, batch, cutoff_lower, cutoff_upper, box_vectors, use_periodic,
-                   max_num_pairs, loop, include_transpose, strategy::brute);
+               tensor_list results;
+               if (positions.size(0) >= 32768) {
+                   // Revert to shared if there are too many particles, which brute can't handle
+                   results = AutogradSharedCUDA::apply(positions, batch, cutoff_lower, cutoff_upper,
+                                                       box_vectors, use_periodic, max_num_pairs,
+                                                       loop, include_transpose);
+               } else {
+                   results = AutogradBruteCUDA::apply(positions, batch, cutoff_lower, cutoff_upper,
+                                                      box_vectors, use_periodic, max_num_pairs,
+                                                      loop, include_transpose);
+               }
                return std::make_tuple(results[0], results[1], results[2], results[3]);
            });
     m.impl("get_neighbor_pairs_shared",
            [](const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
               bool use_periodic, const Scalar& cutoff_lower, const Scalar& cutoff_upper,
               const Scalar& max_num_pairs, bool loop, bool include_transpose) {
-               const tensor_list results = Autograd::apply(
+               const tensor_list results = AutogradSharedCUDA::apply(
                    positions, batch, cutoff_lower, cutoff_upper, box_vectors, use_periodic,
-                   max_num_pairs, loop, include_transpose, strategy::shared);
+                   max_num_pairs, loop, include_transpose);
+               return std::make_tuple(results[0], results[1], results[2], results[3]);
+           });
+    m.impl("get_neighbor_pairs_cell",
+           [](const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
+              bool use_periodic, const Scalar& cutoff_lower, const Scalar& cutoff_upper,
+              const Scalar& max_num_pairs, bool loop, bool include_transpose) {
+               const tensor_list results = AutogradCellCUDA::apply(
+                   positions, batch, box_vectors, use_periodic, cutoff_lower, cutoff_upper,
+                   max_num_pairs, loop, include_transpose);
                return std::make_tuple(results[0], results[1], results[2], results[3]);
            });
 }

--- a/torchmdnet/neighbors/neighbors_cuda_brute.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_brute.cuh
@@ -86,7 +86,7 @@ public:
             std::max((num_all_pairs + num_threads - 1UL) / num_threads, 1UL);
         AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "get_neighbor_pairs_forward", [&]() {
             PairListAccessor<scalar_t> list_accessor(list);
-            triclinic::Box<scalar_t> box(box_vectors);
+            triclinic::Box<scalar_t> box(box_vectors, use_periodic);
             const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
             const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
             TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");

--- a/torchmdnet/neighbors/neighbors_cuda_brute.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_brute.cuh
@@ -1,0 +1,115 @@
+/* Raul P. Pelaez 2023. Brute force neighbor list construction in CUDA.
+
+   A brute force approach that assigns a thread per each possible pair of particles in the system.
+   Based on an implementation by Raimondas Galvelis.
+   Works fantastically for small (less than 10K atoms) systems, but cannot handle more than 32K atoms.
+ */
+#ifndef NEIGHBORS_BRUTE_CUH
+#define NEIGHBORS_BRUTE_CUH
+#include "common.cuh"
+#include <algorithm>
+#include <thrust/extrema.h>
+#include <torch/extension.h>
+
+__device__ uint32_t get_row(uint32_t index) {
+    uint32_t row = floor((sqrtf(8 * index + 1) + 1) / 2);
+    if (row * (row - 1) > 2 * index)
+        row--;
+    return row;
+}
+
+template <typename scalar_t>
+__global__ void forward_kernel_brute(uint32_t num_all_pairs, const Accessor<scalar_t, 2> positions,
+                                     const Accessor<int64_t, 1> batch, scalar_t cutoff_lower2,
+                                     scalar_t cutoff_upper2, PairListAccessor<scalar_t> list,
+                                     triclinic::Box<scalar_t> box) {
+    const uint32_t index = blockIdx.x * blockDim.x + threadIdx.x;
+    if (index >= num_all_pairs)
+        return;
+    const uint32_t row = get_row(index);
+    const uint32_t column = (index - row * (row - 1) / 2);
+    if (batch[row] == batch[column]) {
+        const auto pos_i = fetchPosition(positions, row);
+        const auto pos_j = fetchPosition(positions, column);
+        const auto delta = triclinic::compute_distance(pos_i, pos_j, list.use_periodic, box);
+        const scalar_t distance2 = delta.x * delta.x + delta.y * delta.y + delta.z * delta.z;
+        if (distance2 < cutoff_upper2 && distance2 >= cutoff_lower2) {
+            const scalar_t r2 = sqrt_(distance2);
+            addAtomPairToList(list, row, column, delta, r2, list.include_transpose);
+        }
+    }
+}
+
+template <typename scalar_t>
+__global__ void add_self_kernel(const int num_atoms, Accessor<scalar_t, 2> positions,
+                                PairListAccessor<scalar_t> list) {
+    const int32_t i_atom = blockIdx.x * blockDim.x + threadIdx.x;
+    if (i_atom >= num_atoms)
+        return;
+    __shared__ int i_pair;
+    if (threadIdx.x == 0) { // Each block adds blockDim.x pairs to the list.
+        // Handle the last block, so that only num_atoms are added in total
+        i_pair = atomicAdd(&list.i_curr_pair[0],
+                           thrust::min(blockDim.x, num_atoms - blockIdx.x * blockDim.x));
+    }
+    __syncthreads();
+    scalar3<scalar_t> delta{};
+    scalar_t distance = 0;
+    writeAtomPair(list, i_atom, i_atom, delta, distance, i_pair + threadIdx.x);
+}
+
+class AutogradBruteCUDA : public Function<AutogradBruteCUDA> {
+public:
+    static tensor_list forward(AutogradContext* ctx, const Tensor& positions, const Tensor& batch,
+                               const Scalar& cutoff_lower, const Scalar& cutoff_upper,
+                               const Tensor& box_vectors, bool use_periodic,
+                               const Scalar& max_num_pairs, bool loop, bool include_transpose) {
+        checkInput(positions, batch);
+        const auto max_num_pairs_ = max_num_pairs.toLong();
+        TORCH_CHECK(max_num_pairs_ > 0, "Expected \"max_num_neighbors\" to be positive");
+        if (use_periodic) {
+            TORCH_CHECK(box_vectors.dim() == 2, "Expected \"box_vectors\" to have two dimensions");
+            TORCH_CHECK(box_vectors.size(0) == 3 && box_vectors.size(1) == 3,
+                        "Expected \"box_vectors\" to have shape (3, 3)");
+        }
+        TORCH_CHECK(box_vectors.device() == torch::kCPU, "Expected \"box_vectors\" to be on CPU");
+        const int num_atoms = positions.size(0);
+        TORCH_CHECK(num_atoms < 32768,
+                    "The brute strategy fails with \"num_atoms\" larger than 32768");
+        const int num_pairs = max_num_pairs_;
+        const TensorOptions options = positions.options();
+        const auto stream = getCurrentCUDAStream(positions.get_device());
+        PairList list(num_pairs, positions.options(), loop, include_transpose, use_periodic);
+        const CUDAStreamGuard guard(stream);
+        const uint64_t num_all_pairs = num_atoms * (num_atoms - 1UL) / 2UL;
+        const uint64_t num_threads = 128;
+        const uint64_t num_blocks =
+            std::max((num_all_pairs + num_threads - 1UL) / num_threads, 1UL);
+        AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "get_neighbor_pairs_forward", [&]() {
+            PairListAccessor<scalar_t> list_accessor(list);
+            triclinic::Box<scalar_t> box(box_vectors);
+            const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
+            const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
+            TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");
+            forward_kernel_brute<<<num_blocks, num_threads, 0, stream>>>(
+                num_all_pairs, get_accessor<scalar_t, 2>(positions),
+                get_accessor<int64_t, 1>(batch), cutoff_lower_ * cutoff_lower_,
+                cutoff_upper_ * cutoff_upper_, list_accessor, box);
+            if (loop) {
+                const uint32_t num_threads = 256;
+                const uint32_t num_blocks =
+                    std::max((num_atoms + num_threads - 1U) / num_threads, 1U);
+                add_self_kernel<<<num_blocks, num_threads, 0, stream>>>(
+                    num_atoms, get_accessor<scalar_t, 2>(positions), list_accessor);
+            }
+        });
+        ctx->save_for_backward({list.neighbors, list.deltas, list.distances});
+        ctx->saved_data["num_atoms"] = num_atoms;
+        return {list.neighbors, list.deltas, list.distances, list.i_curr_pair};
+    }
+
+    static tensor_list backward(AutogradContext* ctx, const tensor_list& grad_inputs) {
+        return common_backward(ctx, grad_inputs);
+    }
+};
+#endif

--- a/torchmdnet/neighbors/neighbors_cuda_brute.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_brute.cuh
@@ -8,7 +8,6 @@
 #define NEIGHBORS_BRUTE_CUH
 #include "common.cuh"
 #include <algorithm>
-#include <thrust/extrema.h>
 #include <torch/extension.h>
 
 __device__ uint32_t get_row(uint32_t index) {
@@ -50,7 +49,7 @@ __global__ void add_self_kernel(const int num_atoms, Accessor<scalar_t, 2> posit
     if (threadIdx.x == 0) { // Each block adds blockDim.x pairs to the list.
         // Handle the last block, so that only num_atoms are added in total
         i_pair = atomicAdd(&list.i_curr_pair[0],
-                           thrust::min(blockDim.x, num_atoms - blockIdx.x * blockDim.x));
+                           min(blockDim.x, num_atoms - blockIdx.x * blockDim.x));
     }
     __syncthreads();
     scalar3<scalar_t> delta{};

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cu
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cu
@@ -467,7 +467,6 @@ public:
         Tensor sorted_positions, hash_values;
         std::tie(sorted_positions, hash_values) =
             sortPositionsByHash(positions, batch, box_size, cutoff);
-        cudaDeviceSynchronize();
         Tensor cell_start, cell_end;
         std::tie(cell_start, cell_end) =
             fillCellOffsets(sorted_positions, hash_values, batch, box_size, cutoff);

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cu
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cu
@@ -509,9 +509,6 @@ public:
                             std::to_string(max_num_pairs_),
                         " but found " + std::to_string(num_found_pairs));
         }
-        neighbors.resize_({2, i_curr_pair[0].item<int32_t>()});
-        deltas.resize_({i_curr_pair[0].item<int32_t>(), 3});
-        distances.resize_(i_curr_pair[0].item<int32_t>());
         ctx->save_for_backward({neighbors, deltas, distances});
         ctx->saved_data["num_atoms"] = num_atoms;
         return {neighbors, deltas, distances};

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cu
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cu
@@ -120,15 +120,15 @@ __global__ void assignHash(const Accessor<scalar_t, 2> positions, uint64_t* hash
     const int32_t i_atom = blockIdx.x * blockDim.x + threadIdx.x;
     if (i_atom >= num_atoms)
         return;
-    const int32_t i_batch = batch[i_atom];
+    const uint32_t i_batch = batch[i_atom];
     // Move to the unit cell
     scalar3<scalar_t> pi = {positions[i_atom][0], positions[i_atom][1], positions[i_atom][2]};
     auto ci = getCell(pi, box_size, cutoff);
     // Calculate the hash
-    const int32_t hash = hashMorton(ci);
+    const uint32_t hash = hashMorton(ci);
     // Create a hash combining the Morton hash and the batch index, so that atoms in the same cell
     // are contiguous
-    const int64_t hash_final = (static_cast<int64_t>(hash) << 32) | i_batch;
+    const uint64_t hash_final = (static_cast<uint64_t>(hash) << 32) | i_batch;
     hash_keys[i_atom] = hash_final;
     hash_values[i_atom] = i_atom;
 }

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -38,9 +38,19 @@ __host__ __device__ int3 getCellDimensions(scalar3<scalar_t> box_size, scalar_t 
 template <typename scalar_t>
 __device__ int3 getCell(scalar3<scalar_t> p, scalar3<scalar_t> box_size, scalar_t cutoff,
                         int3 cell_dim) {
-    const int cx = fmodf(floorf((p.x + scalar_t(0.5) * box_size.x) / cutoff), cell_dim.x);
-    const int cy = fmodf(floorf((p.y + scalar_t(0.5) * box_size.y) / cutoff), cell_dim.y);
-    const int cz = fmodf(floorf((p.z + scalar_t(0.5) * box_size.z) / cutoff), cell_dim.z);
+    p = rect::apply_pbc<scalar_t>(p, box_size);
+    // Take to the [0, box_size] range and divide by cutoff (which is the cell size)
+    int cx = floorf((p.x + scalar_t(0.5) * box_size.x) / cutoff);
+    int cy = floorf((p.y + scalar_t(0.5) * box_size.y) / cutoff);
+    int cz = floorf((p.z + scalar_t(0.5) * box_size.z) / cutoff);
+    // Wrap around. If the position of a particle is exactly box_size, it will be in the last cell,
+    // which results in an illegal access down the line.
+    if (cx == cell_dim.x)
+        cx = 0;
+    if (cy == cell_dim.y)
+        cy = 0;
+    if (cz == cell_dim.z)
+        cz = 0;
     return make_int3(cx, cy, cz);
 }
 

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -5,9 +5,7 @@
 #define NEIGHBOR_CUDA_CELL_H
 #include "common.cuh"
 #include <cub/device/device_radix_sort.cuh>
-#include <thrust/device_malloc_allocator.h>
-#include <thrust/device_vector.h>
-
+#include <thrust/extrema.h>
 /*
  * @brief Encodes an unsigned integer lower than 1024 as a 32 bit integer by filling every third
  * bit.

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -4,7 +4,6 @@
 #ifndef NEIGHBOR_CUDA_CELL_H
 #define NEIGHBOR_CUDA_CELL_H
 #include "common.cuh"
-#include <thrust/extrema.h>
 
 /*
  * @brief Calculates the cell dimensions for a given box size and cutoff
@@ -16,9 +15,9 @@ template <typename scalar_t>
 __host__ __device__ int3 getCellDimensions(scalar3<scalar_t> box_size, scalar_t cutoff) {
     int3 cell_dim = make_int3(box_size.x / cutoff, box_size.y / cutoff, box_size.z / cutoff);
     // Minimum 3 cells in each dimension
-    cell_dim.x = thrust::max(cell_dim.x, 3);
-    cell_dim.y = thrust::max(cell_dim.y, 3);
-    cell_dim.z = thrust::max(cell_dim.z, 3);
+    cell_dim.x = max(cell_dim.x, 3);
+    cell_dim.y = max(cell_dim.y, 3);
+    cell_dim.z = max(cell_dim.z, 3);
 // In the host, throw if there are more than 1024 cells in any dimension
 #ifndef __CUDA_ARCH__
     if (cell_dim.x > 1024 || cell_dim.y > 1024 || cell_dim.z > 1024) {
@@ -286,8 +285,8 @@ template <class scalar_t>
 __device__ void addNeighborPair(PairListAccessor<scalar_t>& list, const int i, const int j,
                                 scalar_t distance2, scalar3<scalar_t> delta) {
     const bool requires_transpose = list.include_transpose and (j != i);
-    const int ni = thrust::max(i, j);
-    const int nj = thrust::min(i, j);
+    const int ni = max(i, j);
+    const int nj = min(i, j);
     const scalar_t delta_sign = (ni == i) ? scalar_t(1.0) : scalar_t(-1.0);
     const scalar_t distance = sqrt_(distance2);
     delta = {delta_sign * delta.x, delta_sign * delta.y, delta_sign * delta.z};

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -28,11 +28,12 @@ __host__ __device__ int3 getCellDimensions(scalar3<scalar_t> box_size, scalar_t 
 }
 
 /*
- * @brief Get the cell index of a point
+ * @brief Get the cell coordinates of a point
  * @param p The point position
  * @param box_size The size of the box in each dimension
  * @param cutoff The cutoff
- * @return The cell index
+ * @param cell_dim The number of cells in each dimension
+ * @return The cell coordinates
  */
 template <typename scalar_t>
 __device__ int3 getCell(scalar3<scalar_t> p, scalar3<scalar_t> box_size, scalar_t cutoff,

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -36,20 +36,10 @@ __host__ __device__ int3 getCellDimensions(scalar3<scalar_t> box_size, scalar_t 
  */
 template <typename scalar_t>
 __device__ int3 getCell(scalar3<scalar_t> p, scalar3<scalar_t> box_size, scalar_t cutoff) {
-    p = rect::apply_pbc<scalar_t>(p, box_size);
-    // Take to the [0, box_size] range and divide by cutoff (which is the cell size)
-    int cx = floorf((p.x + scalar_t(0.5) * box_size.x) / cutoff);
-    int cy = floorf((p.y + scalar_t(0.5) * box_size.y) / cutoff);
-    int cz = floorf((p.z + scalar_t(0.5) * box_size.z) / cutoff);
-    int3 cell_dim = getCellDimensions(box_size, cutoff);
-    // Wrap around. If the position of a particle is exactly box_size, it will be in the last cell,
-    // which results in an illegal access down the line.
-    if (cx == cell_dim.x)
-        cx = 0;
-    if (cy == cell_dim.y)
-        cy = 0;
-    if (cz == cell_dim.z)
-        cz = 0;
+    const int3 cell_dim = getCellDimensions(box_size, cutoff);
+    const int cx = fmodf(floorf((p.x + scalar_t(0.5) * box_size.x) / cutoff), cell_dim.x);
+    const int cy = fmodf(floorf((p.y + scalar_t(0.5) * box_size.y) / cutoff), cell_dim.y);
+    const int cz = fmodf(floorf((p.z + scalar_t(0.5) * box_size.z) / cutoff), cell_dim.z);
     return make_int3(cx, cy, cz);
 }
 

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -140,14 +140,13 @@ __global__ void fillCellOffsetsD(const Accessor<scalar_t, 2> sorted_positions,
     const int icell = getCellIndex(getCell(pi, box_size, cutoff), cell_dim);
     int im1_cell;
     if (i_atom > 0) {
-        int im1 = i_atom - 1;
+        const int im1 = i_atom - 1;
         const auto pim1 = fetchPosition(sorted_positions, im1);
         im1_cell = getCellIndex(getCell(pim1, box_size, cutoff), cell_dim);
     } else {
         im1_cell = 0;
     }
     if (icell != im1_cell || i_atom == 0) {
-        int n_cells = cell_start.size(0);
         cell_start[icell] = i_atom;
         if (i_atom > 0) {
             cell_end[im1_cell] = i_atom;
@@ -210,7 +209,7 @@ __device__ int getNeighborCellIndex(int3 cell_i, int i, int3 cell_dim) {
     cell_j.y += (i / 3) % 3 - 1;
     cell_j.z += i / 9 - 1;
     cell_j = getPeriodicCell(cell_j, cell_dim);
-    int icellj = getCellIndex(cell_j, cell_dim);
+    const int icellj = getCellIndex(cell_j, cell_dim);
     return icellj;
 }
 

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -280,14 +280,14 @@ __device__ void addNeighborsForCell(const Particle<scalar_t>& i_atom, int j_cell
         for (int cur_j = first_particle; cur_j < last_particle; cur_j++) {
             const auto j_batch = cl.sorted_batch[cur_j];
             if ((j_batch == i_atom.batch) and
-                ((cur_j < i_atom.index) or (list.loop and cur_j == i_atom.index))) {
+                ((cur_j < i_atom.index) || (list.loop and cur_j == i_atom.index))) {
                 const auto position_j = fetchPosition(cl.sorted_positions, cur_j);
                 const auto delta = rect::compute_distance<scalar_t>(i_atom.position, position_j,
                                                                     list.use_periodic, box_size);
                 const scalar_t distance2 =
                     delta.x * delta.x + delta.y * delta.y + delta.z * delta.z;
-                if ((distance2 < i_atom.cutoff_upper2 and distance2 >= i_atom.cutoff_lower2) or
-                    (list.loop and cur_j == i_atom.index)) {
+                if ((distance2 < i_atom.cutoff_upper2 && distance2 >= i_atom.cutoff_lower2) or
+                    (list.loop && cur_j == i_atom.index)) {
                     const int orj = cl.sorted_indices[cur_j];
                     addNeighborPair(list, i_atom.original_index, orj, distance2, delta);
                 } // endif

--- a/torchmdnet/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_cell.cuh
@@ -124,8 +124,8 @@ __global__ void assignHash(const Accessor<scalar_t, 2> positions, uint64_t* hash
         return;
     const uint32_t i_batch = batch[i_atom];
     // Move to the unit cell
-    scalar3<scalar_t> pi = {positions[i_atom][0], positions[i_atom][1], positions[i_atom][2]};
-    auto ci = getCell(pi, box_size, cutoff);
+    const auto  pi = fetchPosition(positions, i_atom);
+    const auto ci = getCell(pi, box_size, cutoff);
     // Calculate the hash
     const uint32_t hash = hashMorton(ci);
     // Create a hash combining the Morton hash and the batch index, so that atoms in the same cell

--- a/torchmdnet/neighbors/neighbors_cuda_shared.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_shared.cuh
@@ -93,7 +93,7 @@ public:
             positions.scalar_type(), "get_neighbor_pairs_shared_forward", [&]() {
                 const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
                 const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
-                triclinic::Box<scalar_t> box(box_vectors);
+                triclinic::Box<scalar_t> box(box_vectors, use_periodic);
                 TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");
                 constexpr int BLOCKSIZE = 64;
                 const int num_blocks = std::max((num_atoms + BLOCKSIZE - 1) / BLOCKSIZE, 1);

--- a/torchmdnet/neighbors/neighbors_cuda_shared.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_shared.cuh
@@ -1,0 +1,119 @@
+/* Raul P. Pelaez 2023. Shared memory neighbor list construction for CUDA.
+   This brute force approach checks all pairs of atoms by collaborativelly loading and processing
+   tiles of atoms into shared memory.
+   This approach is tipically slower than the brute force approach, but can handle an arbitrarily
+   large number of atoms.
+ */
+#ifndef NEIGHBORS_SHARED_CUH
+#define NEIGHBORS_SHARED_CUH
+#include "common.cuh"
+#include <algorithm>
+#include <thrust/extrema.h>
+#include <torch/extension.h>
+
+template <int BLOCKSIZE, typename scalar_t>
+__global__ void forward_kernel_shared(uint32_t num_atoms, const Accessor<scalar_t, 2> positions,
+                                      const Accessor<int64_t, 1> batch, scalar_t cutoff_lower2,
+                                      scalar_t cutoff_upper2, PairListAccessor<scalar_t> list,
+                                      int32_t num_tiles, triclinic::Box<scalar_t> box) {
+    // A thread per atom
+    const int id = blockIdx.x * blockDim.x + threadIdx.x;
+    // All threads must pass through __syncthreads,
+    // but when N is not a multiple of 32 some threads are assigned a particle i>N.
+    // This threads cant return, so they are masked to not do any work
+    const bool active = id < num_atoms;
+    __shared__ scalar3<scalar_t> sh_pos[BLOCKSIZE];
+    __shared__ int64_t sh_batch[BLOCKSIZE];
+    scalar3<scalar_t> pos_i;
+    int64_t batch_i;
+    if (active) {
+        pos_i = fetchPosition(positions, id);
+        batch_i = batch[id];
+    }
+    // Distribute the N particles in a group of tiles. Storing in each tile blockDim.x values in
+    // shared memory. This way all threads are accesing the same memory addresses at the same time
+    for (int tile = 0; tile < num_tiles; tile++) {
+        // Load this tiles particles values to shared memory
+        const int i_load = tile * blockDim.x + threadIdx.x;
+        if (i_load < num_atoms) { // Even if im not active, my thread may load a value each tile to
+                                  // shared memory.
+            sh_pos[threadIdx.x] = fetchPosition(positions, i_load);
+            sh_batch[threadIdx.x] = batch[i_load];
+        }
+        // Wait for all threads to arrive
+        __syncthreads();
+        // Go through all the particles in the current tile
+#pragma unroll 8
+        for (int counter = 0; counter < blockDim.x; counter++) {
+            if (!active)
+                break; // An out of bounds thread must be masked
+            const int cur_j = tile * blockDim.x + counter;
+            const bool testPair = cur_j < num_atoms and (cur_j < id or (list.loop and cur_j == id));
+            if (testPair) {
+                const auto batch_j = sh_batch[counter];
+                if (batch_i == batch_j) {
+                    const auto pos_j = sh_pos[counter];
+                    const auto delta =
+                        triclinic::compute_distance(pos_i, pos_j, list.use_periodic, box);
+                    const scalar_t distance2 =
+                        delta.x * delta.x + delta.y * delta.y + delta.z * delta.z;
+                    if (distance2 < cutoff_upper2 && distance2 >= cutoff_lower2) {
+                        const bool requires_transpose = list.include_transpose && !(cur_j == id);
+                        const auto distance = sqrt_(distance2);
+                        addAtomPairToList(list, id, cur_j, delta, distance, requires_transpose);
+                    }
+                }
+            }
+        }
+        __syncthreads();
+    }
+}
+
+class AutogradSharedCUDA : public Function<AutogradSharedCUDA> {
+public:
+    static tensor_list forward(AutogradContext* ctx, const Tensor& positions, const Tensor& batch,
+                               const Scalar& cutoff_lower, const Scalar& cutoff_upper,
+                               const Tensor& box_vectors, bool use_periodic,
+                               const Scalar& max_num_pairs, bool loop, bool include_transpose) {
+        checkInput(positions, batch);
+        const auto max_num_pairs_ = max_num_pairs.toLong();
+        TORCH_CHECK(max_num_pairs_ > 0, "Expected \"max_num_neighbors\" to be positive");
+        if (use_periodic) {
+            TORCH_CHECK(box_vectors.dim() == 2, "Expected \"box_vectors\" to have two dimensions");
+            TORCH_CHECK(box_vectors.size(0) == 3 && box_vectors.size(1) == 3,
+                        "Expected \"box_vectors\" to have shape (3, 3)");
+        }
+        TORCH_CHECK(box_vectors.device() == torch::kCPU, "Expected \"box_vectors\" to be on CPU");
+        const int num_atoms = positions.size(0);
+        const int num_pairs = max_num_pairs_;
+        const TensorOptions options = positions.options();
+        const auto stream = getCurrentCUDAStream(positions.get_device());
+        PairList list(num_pairs, positions.options(), loop, include_transpose, use_periodic);
+        const CUDAStreamGuard guard(stream);
+        AT_DISPATCH_FLOATING_TYPES(
+            positions.scalar_type(), "get_neighbor_pairs_shared_forward", [&]() {
+                const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
+                const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
+                triclinic::Box<scalar_t> box(box_vectors);
+                TORCH_CHECK(cutoff_upper_ > 0, "Expected \"cutoff\" to be positive");
+                constexpr int BLOCKSIZE = 64;
+                const int num_blocks = std::max((num_atoms + BLOCKSIZE - 1) / BLOCKSIZE, 1);
+                const int num_threads = BLOCKSIZE;
+                const int num_tiles = num_blocks;
+                PairListAccessor<scalar_t> list_accessor(list);
+                forward_kernel_shared<BLOCKSIZE><<<num_blocks, num_threads, 0, stream>>>(
+                    num_atoms, get_accessor<scalar_t, 2>(positions),
+                    get_accessor<int64_t, 1>(batch), cutoff_lower_ * cutoff_lower_,
+                    cutoff_upper_ * cutoff_upper_, list_accessor, num_tiles, box);
+            });
+        ctx->save_for_backward({list.neighbors, list.deltas, list.distances});
+        ctx->saved_data["num_atoms"] = num_atoms;
+        return {list.neighbors, list.deltas, list.distances, list.i_curr_pair};
+    }
+
+    static tensor_list backward(AutogradContext* ctx, const tensor_list& grad_inputs) {
+        return common_backward(ctx, grad_inputs);
+    }
+};
+
+#endif

--- a/torchmdnet/neighbors/neighbors_cuda_shared.cuh
+++ b/torchmdnet/neighbors/neighbors_cuda_shared.cuh
@@ -8,7 +8,6 @@
 #define NEIGHBORS_SHARED_CUH
 #include "common.cuh"
 #include <algorithm>
-#include <thrust/extrema.h>
 #include <torch/extension.h>
 
 template <int BLOCKSIZE, typename scalar_t>


### PR DESCRIPTION
This PR includes a new module called DistanceCellList (looking for a better name), which is an alternative to the [Distance](https://github.com/torchmd/torchmd-net/blob/main/torchmdnet/models/utils.py#L195-L203) module that provides three strategies to find neighbors:
 1. The O(N^2) [getNeighborPairs functionality from NNPops](https://github.com/openmm/NNPOps/blob/master/src/pytorch/neighbors/getNeighborPairs.py), referred to as **brute**, which required making it batch-aware. The batching functionality is actually a really minimal modification, so this could be upstreamed to NNPops and that used instead.
 2. A **cell** list distance module, using a classic spatial hashing approach (see [here](https://uammd.readthedocs.io/en/latest/NeighbourList.html#celllist))
 3. An improved O(N^2) approach referred to as **shared** (from NVIDIA [here](https://developer.nvidia.com/gpugems/gpugems3/part-v-physics-simulation/chapter-31-fast-n-body-simulation-cuda))

The current Distance module has some drawbacks:
 1. Really slow for a single batch
 2. Does not understand periodic boundary conditions
 3. Incompatible with CUDA graphs
 4. Always returns redundant pairs (give you i,j and j,i). This is required for the current Message Passing modules.
 
The new module solves all these by being:
1. Two orders of magnitude faster for a single batch (while being at least as fast as Distance in all instances tested)
2. CUDA graph compatible (and jit.script compatible)
3. Drop in replacement to Distance when using default parameters*.
4. Compatible with periodic boundary conditions.
5. Able to optionally skip redundant neighbors, saving time and memory.
6. 
*There is a caveat, Distance requires max_num_neighs (maximum allows neighbors per particle), DistanceCellList requires max_num_pairs (maximum number of total neighbor pairs).
```python
#From DistanceCellList:
"""
        max_num_pairs : int
            Maximum number of pairs to store.
            If negative, it is interpreted as (minus) the maximum number of neighbors per atom.
"""
```
This is the current declaration of the new module:
https://github.com/torchmd/torchmd-net/blob/730b0a17c6dc4d4fdc2b1d9b8769c80cfd765210/torchmdnet/models/utils.py#L81-L129

### Changes to the installation process

This operation is written in C++ and CUDA. TorchMD-Net does not currently have an in place build system being only python.
I build this as a [torch cpp_extension with jit compilation 
](https://pytorch.org/tutorials/advanced/torch_script_custom_ops.html#building-with-jit-compilation). Meaning that the CUDA/C++ code is compiled transparently the first time DistanceCellList is instantiated in a way compatible with the current "pip install -e ." workflow.
If an user does not use the new module, nothing is compiled and no additional dependencies/overhead are required.

OTOH, a user constructing DistanceCellList will:
1. Require NVCC installed with a CUDA version ABI compatible with torch (cudatoolkit-dev from conda-forge works)
2. Experience a several minutes compilation time the first time DistanceCellList is used after "pip install -e ." (torch will cache the compilation).
 
### Tasks:
- [x] Adapt the neighbor functions in NNPops to torchmd-net "pip install -e ." installation (thanks #61).
- [x] Implement a batch-aware cell list neighbor construction
- - [x] Optimize the cell list.
- - [x] Make the operation CUDA graph compatible
- [x] Add tests
- [x] Add benchmark 
- [x] Feature parity with current ```Distance``` module.
- - [x] Add the "loop" parameter (include self-interactions)
- - [x] Add the "cutoff_lower" parameter
- Add periodic boundary conditions
- - [x] Support rectangular boxes
- - [ ] Support triclinic boxes
- - - [x] Brute force 
- - - [ ] Cell list
- [x] Add backwards pass
- - [x] CPU (Autograd takes care of it)
- - [x] GPU (common backwards pass for every strategy)
- [x] torch.jit.script compatibility

### Challenges:

1. The brute approach cannot handle more than 32K particles total. AFAIK, there is no way to make it work without destroying what makes it be so fast. Anyhow, this strategy is not really suited for such high workloads. There is a guard that simply forces the shared strategy to be used if the user selected brute but more than 32K particles are requested.
2. The performance of the cell strategy degrades quickly with the number of batches. This is because I construct a single cell list such that particles with the same cell are contiguous in memory. When traversing the cell list, one thus finds particles from all batches, forcing a lot of unnecessary checks. I mitigate this by sorting by batch inside each cell, allowing to skip some pairs, but this could be done in a more smart way, I am sure (maybe a binary search looking for the first atom in the current particle`s batch?).
The alternative, constructing a cell list per batch, requires much more memory and cannot be done without GPU-CPU memory copies.  
3. Automatically choosing a strategy based on some heuristic. I tried this in a million ways, but jit.script is not taking it.  The heuristic cannot be applied until the forward method (when positions and batch are known), changing the function dynamically like that is just not something that TorchScript supports as far as I can tell.