### PR TITLE
Update md17

### DIFF
--- a/torchmdnet/datasets/md17.py
+++ b/torchmdnet/datasets/md17.py
@@ -13,14 +13,14 @@ class MD17(InMemoryDataset):
     raw_url = "http://www.quantum-machine.org/gdml/data/npz/"
 
     molecule_files = dict(
-        aspirin="aspirin_dft.npz",
-        benzene="benzene_old_dft.npz",
-        ethanol="ethanol_dft.npz",
-        malonaldehyde="malonaldehyde_dft.npz",
-        naphthalene="naphthalene_dft.npz",
-        salicylic_acid="salicylic_dft.npz",
-        toluene="toluene_dft.npz",
-        uracil="uracil_dft.npz",
+        aspirin="md17_aspirin.npz",
+        benzene="md17_benzene2017.npz",
+        ethanol="md17_ethanol.npz",
+        malonaldehyde="md17_malonaldehyde.npz",
+        naphthalene="md17_naphthalene.npz",
+        salicylic_acid="md17_salicylic.npz",
+        toluene="md17_toluene.npz",
+        uracil="md17_uracil.npz",
     )
 
     available_molecules = list(molecule_files.keys())


### PR DESCRIPTION
The file names used in the MD17 dataloader (torchmdnet/datasets/md17.py) have become obsolete. This pull request (PR) aims to update all the file names in accordance with the latest release available at http://www.quantum-machine.org/gdml/data/npz/. 