### PR TITLE
Enable the Ace loader to return a conformation index

### DIFF
--- a/torchmdnet/datasets/ace.py
+++ b/torchmdnet/datasets/ace.py
@@ -162,7 +162,7 @@ class Ace(Dataset):
                 mols = list(h5.values())[0].items()
                 load_confs = self._load_confs_2_0
             else:
-                raise RuntimeError(f"Unsuported layout verions: {version}")
+                raise RuntimeError(f"Unsupported layout version: {version}")
 
             # Iterate over the molecules
             for i_mol, (mol_id, mol) in tqdm(


### PR DESCRIPTION
Enable the Ace loader to return a conformation index

```python
ds = Ace('.', paths='dataset.h5')
for s in ds.sample_iter(mol_ids=True):
    print(s)

Data(y=[1, 1], pos=[12, 3], z=[12], neg_dy=[12, 3], q=0, pq=[12], dp=[3])
...

for s in ds.sample_iter(mol_ids=True):
    print(s)

Data(y=[1, 1], pos=[12, 3], z=[12], neg_dy=[12, 3], q=0, pq=[12], dp=[3], mol_id='C4H5N3', i_conf=10355)
...

```