### PR TITLE
Wandb resume

### DIFF
--- a/torchmdnet/calculators.py
+++ b/torchmdnet/calculators.py
@@ -11,7 +11,7 @@ tranforms = {
         energy * 627.509,
         forces * 627.509 / 0.529177,
     ),  # Hartree -> kcal/mol, Hartree/Bohr -> kcal/mol/A
-    "Haetree/A -> kcal/mol/A": lambda energy, forces: (
+    "Hartree/A -> kcal/mol/A": lambda energy, forces: (
         energy * 627.509,
         forces * 627.509,
     ),  # Hartree -> kcal/mol, Hartree/A -> kcal/mol/A

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -98,6 +98,8 @@ def get_args():
     parser.add_argument('--wandb-use', default=False, type=bool, help='Defines if wandb is used or not')
     parser.add_argument('--wandb-name', default='training', type=str, help='Give a name to your wandb run')
     parser.add_argument('--wandb-project', default='training_', type=str, help='Define what wandb Project to log to')
+    parser.add_argument('--wandb-resume', default=False, type=bool, help='Defines if wandb run should be resumed')
+    parser.add_argument('--wandb-id', default=None, type=str, help='Define what wandb run to resume, you can find the id from the wandb table')
     parser.add_argument('--tensorboard-use', default=False, type=bool, help='Defines if tensor board is used or not')
 
     # fmt: on
@@ -146,7 +148,10 @@ def main():
     csv_logger = CSVLogger(args.log_dir, name="", version="")
     _logger=[csv_logger]
     if args.wandb_use:
-        wandb_logger=WandbLogger(project=args.wandb_project,name=args.wandb_name,save_dir=args.log_dir)
+        if args.wandb_resume and args.wandb_id is not None:
+            wandb_logger=WandbLogger(project=args.wandb_project, save_dir=args.log_dir, resume='must', id=args.wandb_id)
+        else:
+            wandb_logger=WandbLogger(project=args.wandb_project,name=args.wandb_name, save_dir=args.log_dir)
         _logger.append(wandb_logger)
 
     if args.tensorboard_use:

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -98,7 +98,7 @@ def get_args():
     parser.add_argument('--wandb-use', default=False, type=bool, help='Defines if wandb is used or not')
     parser.add_argument('--wandb-name', default='training', type=str, help='Give a name to your wandb run')
     parser.add_argument('--wandb-project', default='training_', type=str, help='Define what wandb Project to log to')
-    parser.add_argument('--wandb-resume-from-id', default=None, type=str, help='Resume a wandb run from a given run id, retrieve the run id from the wandb dashboard')
+    parser.add_argument('--wandb-resume-from-id', default=None, type=str, help='Resume a wandb run from a given run id. The id can be retrieved from the wandb dashboard')
     parser.add_argument('--tensorboard-use', default=False, type=bool, help='Defines if tensor board is used or not')
 
     # fmt: on

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -98,8 +98,7 @@ def get_args():
     parser.add_argument('--wandb-use', default=False, type=bool, help='Defines if wandb is used or not')
     parser.add_argument('--wandb-name', default='training', type=str, help='Give a name to your wandb run')
     parser.add_argument('--wandb-project', default='training_', type=str, help='Define what wandb Project to log to')
-    parser.add_argument('--wandb-resume', default=False, type=bool, help='Defines if wandb run should be resumed')
-    parser.add_argument('--wandb-id', default=None, type=str, help='Define what wandb run to resume, you can find the id from the wandb table')
+    parser.add_argument('--wandb-resume-from-id', default=None, type=str, help='Resume a wandb run from a given run id, retrieve the run id from the wandb dashboard')
     parser.add_argument('--tensorboard-use', default=False, type=bool, help='Defines if tensor board is used or not')
 
     # fmt: on
@@ -148,17 +147,13 @@ def main():
     csv_logger = CSVLogger(args.log_dir, name="", version="")
     _logger = [csv_logger]
     if args.wandb_use:
-        if args.wandb_resume and args.wandb_id is not None:
-            wandb_logger = WandbLogger(
-                project=args.wandb_project,
-                save_dir=args.log_dir,
-                resume="must",
-                id=args.wandb_id,
-            )
-        else:
-            wandb_logger = WandbLogger(
-                project=args.wandb_project, name=args.wandb_name, save_dir=args.log_dir
-            )
+        wandb_logger = WandbLogger(
+            project=args.wandb_project,
+            name=args.wandb_name,
+            save_dir=args.log_dir,
+            resume="must" if args.wandb_resume_from_id is not None else None,
+            id=args.wandb_resume_from_id,
+        )
         _logger.append(wandb_logger)
 
     if args.tensorboard_use:

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -146,12 +146,19 @@ def main():
     early_stopping = EarlyStopping("val_loss", patience=args.early_stopping_patience)
 
     csv_logger = CSVLogger(args.log_dir, name="", version="")
-    _logger=[csv_logger]
+    _logger = [csv_logger]
     if args.wandb_use:
         if args.wandb_resume and args.wandb_id is not None:
-            wandb_logger=WandbLogger(project=args.wandb_project, save_dir=args.log_dir, resume='must', id=args.wandb_id)
+            wandb_logger = WandbLogger(
+                project=args.wandb_project,
+                save_dir=args.log_dir,
+                resume="must",
+                id=args.wandb_id,
+            )
         else:
-            wandb_logger=WandbLogger(project=args.wandb_project,name=args.wandb_name, save_dir=args.log_dir)
+            wandb_logger = WandbLogger(
+                project=args.wandb_project, name=args.wandb_name, save_dir=args.log_dir
+            )
         _logger.append(wandb_logger)
 
     if args.tensorboard_use:


### PR DESCRIPTION
In certain scenarios, there is a need to resume training without creating a new wandb logger, for example killed or crashed process. The purpose of this pull request is to incorporate this functionality directly into the tochmd-net code, enabling users to have this possibility directly from the YAML conf file. To achieve this, two new arguments have been introduced: 

- `wandb-resume` (boolean); 
- `wandb-id`, the ID of the run to be resumed (it's possible to retrieve it from the project table on the wandb-page); 