### PR TITLE
[DNM] Make setup.py compile/install  Cpp extensions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 import subprocess
 from setuptools import setup, find_packages
+import os
+import torch
+from torch.utils.cpp_extension import CppExtension, BuildExtension, CUDAExtension
 
 try:
     version = (
@@ -11,11 +14,22 @@ except:
     print("Failed to retrieve the current version, defaulting to 0")
     version = "0"
 
+src_dir = os.path.join(os.path.dirname(os.path.realpath(__file__)), "torchmdnet", "neighbors")
+sources = ["neighbors.cpp", "neighbors_cpu.cpp"] + (
+    ["neighbors_cuda.cu", "backwards.cu"] if torch.cuda.is_available() else []
+)
+sources = [os.path.join(src_dir, name) for name in sources]
+Ext = CUDAExtension if torch.cuda.is_available() else CppExtension
+extension = Ext(
+    name="torchmdnet_neighbors", sources=sources
+)
+
 setup(
     name="torchmd-net",
     version=version,
+    description="TorchMD-Net: A PyTorch-based Deep Learning Framework for Molecular Dynamics",
+    ext_modules=[extension],
+    cmdclass={"build_ext": BuildExtension},
     packages=find_packages(),
-    package_data={"torchmdnet": ["neighbors/neighbors*", "neighbors/*.cu*"]},
-    include_package_data=True,
     entry_points={"console_scripts": ["torchmd-train = torchmdnet.scripts.train:main"]},
 )

--- a/torchmdnet/neighbors/__init__.py
+++ b/torchmdnet/neighbors/__init__.py
@@ -1,16 +1,3 @@
-import os
 import torch
-from torch.utils import cpp_extension
-
-def compile_extension():
-    src_dir = os.path.dirname(__file__)
-    sources = ["neighbors.cpp", "neighbors_cpu.cpp"] + (
-        ["neighbors_cuda.cu", "backwards.cu"] if torch.cuda.is_available() else []
-    )
-    sources = [os.path.join(src_dir, name) for name in sources]
-    cpp_extension.load(
-        name="torchmdnet_neighbors", sources=sources, is_python_module=False
-    )
-
-compile_extension()
-get_neighbor_pairs_kernel = torch.ops.torchmdnet_neighbors.get_neighbor_pairs
+from torchmdnet_neighbors import get_neighbor_pairs
+get_neighbor_pairs_kernel = get_neighbor_pairs

--- a/torchmdnet/neighbors/neighbors.cpp
+++ b/torchmdnet/neighbors/neighbors.cpp
@@ -1,5 +1,5 @@
 #include <torch/extension.h>
 
-TORCH_LIBRARY(torchmdnet_neighbors, m) {
+TORCH_LIBRARY(TORCH_EXTENSION_NAME, m) {
     m.def("get_neighbor_pairs(str strategy, Tensor positions, Tensor batch, Tensor box_vectors, bool use_periodic, Scalar cutoff_lower, Scalar cutoff_upper, Scalar max_num_pairs, bool loop, bool include_transpose) -> (Tensor neighbors, Tensor distances, Tensor distance_vecs, Tensor num_pairs)");
 }

--- a/torchmdnet/neighbors/neighbors_cpu.cpp
+++ b/torchmdnet/neighbors/neighbors_cpu.cpp
@@ -89,7 +89,7 @@ forward(const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
     return {neighbors, deltas, distances, num_pairs_found};
 }
 
-TORCH_LIBRARY_IMPL(torchmdnet_neighbors, CPU, m) {
+TORCH_LIBRARY_IMPL(TORCH_EXTENSION_NAME, CPU, m) {
   m.impl("get_neighbor_pairs", [](const std::string &strategy,  const Tensor& positions, const Tensor& batch, const Tensor& box_vectors,
 				    bool use_periodic, const Scalar& cutoff_lower, const Scalar& cutoff_upper,
               const Scalar& max_num_pairs, bool loop, bool include_transpose) {

--- a/torchmdnet/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/neighbors/neighbors_cuda.cu
@@ -63,7 +63,7 @@ public:
     }
 };
 
-TORCH_LIBRARY_IMPL(torchmdnet_neighbors, AutogradCUDA, m) {
+TORCH_LIBRARY_IMPL(TORCH_EXTENSION_NAME, AutogradCUDA, m) {
     m.impl("get_neighbor_pairs",
            [](const std::string& strategy, const Tensor& positions, const Tensor& batch,
               const Tensor& box_vectors, bool use_periodic, const Scalar& cutoff_lower,


### PR DESCRIPTION
Currently cpp extensions are JIT compiled when first imported. This causes a lot of time consuming recompilation.
I am trying to instead compile them to a library in setup.py, but failing miserably. 

I followed this pytorch tutorial: https://pytorch.org/tutorials/advanced/cpp_extension.html

My modifications correctly generate a library in the right place, but when I try to import it I get an error:
```
>   from torchmdnet_neighbors import get_neighbor_pairs
E   ImportError: dynamic module does not define module export function (PyInit_torchmdnet_neighbors)
```
Dissasembling this library shows that there is in fact no PyInit function. I do not know what I am missing here. 

According to the tutorial, torch must be imported first, which I am doing to no avail.

I am PRing here to see if anyone has any idea!