### PR TITLE
Fix bug in TN

### DIFF
--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -402,7 +402,7 @@ class Interaction(MessagePassing):
         A = self.linears_tensor[4](A.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
         S = self.linears_tensor[5](S.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
         dX = I + A + S
-        X = X + dX + dX**2
+        X = X + dX + torch.matmul(dX,dX)
         return X
 
     def message(self, I_j, A_j, S_j, edge_attr):


### PR DESCRIPTION
A dX**2 operation should be a torch.matmul(dX,dX).