### PR TITLE
Make all tensor representations 4x4 matrices

### DIFF
--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -20,7 +20,7 @@ def vector_to_skewtensor(vector):
             zero,
             -vector[:, 2],
             vector[:, 1],
-            zero
+            zero,
             vector[:, 2],
             zero,
             -vector[:, 0],

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -20,21 +20,26 @@ def vector_to_skewtensor(vector):
             zero,
             -vector[:, 2],
             vector[:, 1],
+            zero
             vector[:, 2],
             zero,
             -vector[:, 0],
+            zero
             -vector[:, 1],
             vector[:, 0],
+            zero,
             zero,
         ),
         dim=1,
     )
-    tensor = tensor.view(-1, 3, 3)
+    tensor = tensor.view(-1, 4, 4)
     return tensor.squeeze(0)
 
 
 # Creates a symmetric traceless tensor from the outer product of a vector with itself
 def vector_to_symtensor(vector):
+    # This can be done in other ways for sure
+    vector = torch.cat((vector, torch.zeros(vector.shape[0],1,device=vector.device)),dim=-1)
     tensor = torch.matmul(vector.unsqueeze(-1), vector.unsqueeze(-2))
     I = (tensor.diagonal(offset=0, dim1=-1, dim2=-2)).mean(-1)[
         ..., None, None

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -45,18 +45,22 @@ def vector_to_symtensor(vector):
     # This can be done in other ways for sure
     vector = torch.cat((vector, torch.zeros(vector.shape[0],1,device=vector.device)),dim=-1)
     tensor = torch.matmul(vector.unsqueeze(-1), vector.unsqueeze(-2))
-    I = (tensor.diagonal(offset=0, dim1=-1, dim2=-2)).mean(-1)[
+    I = torch.eye(4,4, device=tensor.device, dtype=tensor.dtype)
+    I[3,3] = 0.
+    I = (1/3)*(tensor.diagonal(offset=0, dim1=-1, dim2=-2)).sum(-1)[
         ..., None, None
-    ] * torch.eye(3, 3, device=tensor.device, dtype=tensor.dtype)
+    ] * I
     S = 0.5 * (tensor + tensor.transpose(-2, -1)) - I
     return S
 
 
 # Full tensor decomposition into irreducible components
 def decompose_tensor(tensor):
-    I = (tensor.diagonal(offset=0, dim1=-1, dim2=-2)).mean(-1)[
+    I = torch.eye(4,4, device=tensor.device, dtype=tensor.dtype)
+    I[3,3] = 0.
+    I = (1/3)*(tensor.diagonal(offset=0, dim1=-1, dim2=-2)).sum(-1)[
         ..., None, None
-    ] * torch.eye(3, 3, device=tensor.device, dtype=tensor.dtype)
+    ] * I
     A = 0.5 * (tensor - tensor.transpose(-2, -1))
     S = 0.5 * (tensor + tensor.transpose(-2, -1)) - I
     return I, A, S

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -290,9 +290,8 @@ class TensorEmbedding(MessagePassing):
         mask = edge_index[0] != edge_index[1]
         edge_vec[mask] = edge_vec[mask] / torch.norm(edge_vec[mask], dim=1).unsqueeze(1)
         # Raul: dtype here?
-        Id = torch.zeros(4, 1, device=edge_vec.device)
-        Id[:3] = 1.
-        Id = torch.diag_embed(Id)
+        Id = torch.eye(4, 4 device=edge_vec.device, dtype=edge_vec.dtype)
+        Id[3,3] = 0.
         Iij, Aij, Sij = new_radial_tensor(
             Id[None, None, :, :],
             vector_to_skewtensor(edge_vec)[..., None, :, :],

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -29,6 +29,10 @@ def vector_to_skewtensor(vector):
             vector[:, 0],
             zero,
             zero,
+            zero,
+            zero,
+            zero,
+            zero,
         ),
         dim=1,
     )

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -281,10 +281,12 @@ class TensorEmbedding(MessagePassing):
         W3 = self.distance_proj3(edge_attr) * C.view(-1, 1)
         mask = edge_index[0] != edge_index[1]
         edge_vec[mask] = edge_vec[mask] / torch.norm(edge_vec[mask], dim=1).unsqueeze(1)
+        # Raul: dtype here?
+        Id = torch.zeros(4, 1, device=edge_vec.device)
+        Id[:3] = 1.
+        Id = torch.diag_embed(Id)
         Iij, Aij, Sij = new_radial_tensor(
-            torch.eye(3, 3, device=edge_vec.device, dtype=edge_vec.dtype)[
-                None, None, :, :
-            ],
+            Id[None, None, :, :],
             vector_to_skewtensor(edge_vec)[..., None, :, :],
             vector_to_symtensor(edge_vec)[..., None, :, :],
             W1,

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -290,7 +290,7 @@ class TensorEmbedding(MessagePassing):
         mask = edge_index[0] != edge_index[1]
         edge_vec[mask] = edge_vec[mask] / torch.norm(edge_vec[mask], dim=1).unsqueeze(1)
         # Raul: dtype here?
-        Id = torch.eye(4, 4 device=edge_vec.device, dtype=edge_vec.dtype)
+        Id = torch.eye(4, 4, device=edge_vec.device, dtype=edge_vec.dtype)
         Id[3,3] = 0.
         Iij, Aij, Sij = new_radial_tensor(
             Id[None, None, :, :],

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -24,7 +24,7 @@ def vector_to_skewtensor(vector):
             vector[:, 2],
             zero,
             -vector[:, 0],
-            zero
+            zero,
             -vector[:, 1],
             vector[:, 0],
             zero,


### PR DESCRIPTION
This PR is a slight modification of TensorNet, which should make current 3x3 tensors become 4x4 (the original 3x3 padded with zeros to become 4x4), such that mathematically operations are equivalent on the 3x3 blocks but we enable the use of tensor cores.

@RaulPPelaez , there is some dtype that should be taken care of.