### PR TITLE
fix lightning hparams conflict

### DIFF
--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -181,6 +181,7 @@ def main():
 
     # run test set after completing the fit
     model = LNNP.load_from_checkpoint(trainer.checkpoint_callback.best_model_path)
+    data.save_hyperparameters(model.hparams)
     trainer = pl.Trainer(logger=_logger)
     trainer.test(model, data)
 


### PR DESCRIPTION
DO NOT MERGE YET! 

In PyTorch Lightning, the LightningModule and LightningDataModule are two separate components with distinct responsibilities. Occasionally, conflicts in hyperparameters may arise between the model and the data loading process, causing issues during training or inference.
For example, in the case that I'm reporting the error comes out when the test is going to be performed because the `best_model.ckpt` was saved before than I resumed a training using `load_model` and from this the keys mismatch. One approach to fix it, is to update the `data.hparams ` using the model.hparams. (change proposed by this PR).

![image](https://github.com/torchmd/torchmd-net/assets/101815262/49661f57-9705-46f1-a9df-109b60922031)

It's also true that maybe should not be allowed to have a lot of  difference in the hparams between the data and the model but just some keys like `load_model`; if this is the case maybe the best solution is to write a function like: 
```
def fix_lightning_conflict(model, data):
    """This function inspects the hyperparameters of the model and data and fix any conflicts by providing a consistent 
        set of hyperparameters for both components. It ensures that key hyperparameters such as batch size, learning rate, etc., 
        are coherent between the model and data loading only if the hparms key is in the allowed_conflicts list"""

    allowed_conflicts = ["load_model"]
    model_hparams = model.hparams
    data_hparams = data.hparams

    for parm in model_hparams:
        if parm in allowed_conflicts and model_hparams[parm] != data_hparams[parm]:
            rank_zero_warn(
                f"Conflict between model and dataset hparams for {parm}! "
                f"Using {model_hparams[parm]} from the model."
            )
            data_hparams[parm] = model_hparams[parm]

    return data_hparams
```
