### PR TITLE
Fix module.py

### DIFF
--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -165,15 +165,12 @@ class LNNP(LightningModule):
             step_losses = self._compute_losses(y, neg_dy, batch, loss_fn, stage)
 
             loss_name = loss_fn.__name__
-
             if self.hparams.neg_dy_weight > 0:
                 self.losses[stage]["neg_dy"][loss_name].append(
                     step_losses["neg_dy"].detach()
                 )
-
             if self.hparams.y_weight > 0:
                 self.losses[stage]["y"][loss_name].append(step_losses["y"].detach())
-
             total_loss = (
                 step_losses["y"] * self.hparams.y_weight
                 + step_losses["neg_dy"] * self.hparams.neg_dy_weight

--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -107,7 +107,10 @@ class LNNP(LightningModule):
         if "y" in batch:
             loss_y = loss_fn(y, batch.y)
             loss_y = self._update_loss_with_ema(stage, "y", loss_name, loss_y)
-        return {"y": loss_y, "neg_dy": loss_neg_y}
+        return {
+            "y": loss_y if torch.is_tensor(loss_y) else torch.zeros(()),
+            "neg_dy": loss_neg_y if torch.is_tensor(loss_neg_y) else torch.zeros(()),
+        }
 
     def _update_loss_with_ema(self, stage, type, loss_name, loss):
         # Update the loss using an exponential moving average when applicable

--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -221,11 +221,6 @@ class LNNP(LightningModule):
             result_dict.update(self._get_mean_loss_dict_for_type("total"))
             result_dict.update(self._get_mean_loss_dict_for_type("y"))
             result_dict.update(self._get_mean_loss_dict_for_type("neg_dy"))
-            # For retro compatibility with previous versions of TorchMD-Net we report some losses twice
-            result_dict["val_loss"] = result_dict["val_total_mse_loss"]
-            result_dict["train_loss"] = result_dict["train_total_mse_loss"]
-            if "test_total_l1_loss" in result_dict:
-                result_dict["test_loss"] = result_dict["test_total_l1_loss"]
             self.log_dict(result_dict, sync_dist=True)
 
         self._reset_losses_dict()

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -29,7 +29,7 @@ def get_args():
     parser.add_argument('--inference-batch-size', default=None, type=int, help='Batchsize for validation and tests.')
     parser.add_argument('--lr', default=1e-4, type=float, help='learning rate')
     parser.add_argument('--lr-patience', type=int, default=10, help='Patience for lr-schedule. Patience per eval-interval of validation')
-    parser.add_argument('--lr-metric', type=str, default='val_loss', choices=['train_loss', 'val_loss'], help='Metric to monitor when deciding whether to reduce learning rate')
+    parser.add_argument('--lr-metric', type=str, default='val_total_mse_loss', choices=['train_total_mse_loss', 'val_total_mse_loss'], help='Metric to monitor when deciding whether to reduce learning rate')
     parser.add_argument('--lr-min', type=float, default=1e-6, help='Minimum learning rate before early stop')
     parser.add_argument('--lr-factor', type=float, default=0.8, help='Factor by which to multiply the learning rate when the metric stops improving')
     parser.add_argument('--lr-warmup-steps', type=int, default=0, help='How many steps to warm-up over. Defaults to 0 for no warm-up')
@@ -140,12 +140,15 @@ def main():
 
     checkpoint_callback = ModelCheckpoint(
         dirpath=args.log_dir,
-        monitor="val_loss",
+        monitor="val_total_mse_loss",
         save_top_k=10,  # -1 to save all
         every_n_epochs=args.save_interval,
-        filename="{epoch}-{val_loss:.4f}-{test_loss:.4f}",
+        filename="epoch={epoch}-val_loss={val_total_mse_loss:.4f}-test_loss={test_total_l1_loss:.4f}",
+        auto_insert_metric_name=False,
     )
-    early_stopping = EarlyStopping("val_loss", patience=args.early_stopping_patience)
+    early_stopping = EarlyStopping(
+        "val_total_mse_loss", patience=args.early_stopping_patience
+    )
 
     csv_logger = CSVLogger(args.log_dir, name="", version="")
     _logger = [csv_logger]


### PR DESCRIPTION
- [x] `compute_losses` output return a dict with "y" and "neg_dy"; these 2 variables are initialized as float: 
	- if "derivative" is set to false or "neg_dy" not in batch, the neg_dy output is a float and .detach() function called in step give an error;
	- if "y" not in batch, "y" is a float (0.0) and the detach function called in step give an error; 
 According to the old version of the code I added a check for `neg_dy_weight` and `y_weight `
- [x] wandb error:
	- if you want to train with just "y" or "neg_dy", wandb should visualize only the relative metrics;
	- remove same metrics with different name (redundant), I modified `ModelCheckpoint()`; 