### PR TITLE
Fix trying to detach a float number in LNNP

### DIFF
--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -97,7 +97,9 @@ class LNNP(LightningModule):
         # Returns:
         #   loss_y: loss for the predicted value
         #   loss_neg_y: loss for the predicted negative derivative
-        loss_y, loss_neg_y = 0.0, 0.0
+        loss_y, loss_neg_y = torch.tensor(0.0, device=self.device), torch.tensor(
+            0.0, device=self.device
+        )
         loss_name = loss_fn.__name__
         if self.hparams.derivative and "neg_dy" in batch:
             loss_neg_y = loss_fn(neg_y, batch.neg_dy)


### PR DESCRIPTION
If the user trains with only energy or only forces in some situations the LNNP class will try to call detach on a float where it expects a tensor.
I changed the loss computation so it initializes the losses on both energy and force as a torch.tensor.