### PR TITLE
[WIP] fix stride warning

### DIFF
--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -173,7 +173,7 @@ def main():
         )
 
     trainer = pl.Trainer(
-        strategy=DDPStrategy(find_unused_parameters=False),
+        strategy="auto",
         max_epochs=args.num_epochs,
         accelerator="auto",
         devices=args.ngpus,


### PR DESCRIPTION
When you train on a single GPU the following warning raise up:
```
UserWarning: Grad strides do not match bucket view strides. This may indicate grad was not created according 
to the gradient layout contract, or that the param's strides changed since DDP was constructed. This is not an 
error, but may impair performance.
grad.sizes() = [1, 64], strides() = [1, 1]
bucket_view.sizes() = [1, 64], strides() = [64, 1]
``` 
In order to remove this warning I'm proposing in this PR to change the strategy used in the `pl.Trainer()` to "auto".  Another way could be to set the strategy based on the GPUs involved in the training. 