### PR TITLE
Preload small datasets to memory in Custom dataset

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -10,7 +10,7 @@ import h5py
 import glob
 
 def write_sample_npy_files(energy, forces, tmpdir, num_files):
-        # set up necessary files
+    # set up necessary files
     n_atoms = np.random.randint(2, 10, size=num_files)
     num_samples = np.random.randint(10, 100, size=num_files)
     #n_atoms repeated num_samples times for each file

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -55,6 +55,14 @@ def test_custom(energy, forces, num_files, preload, tmpdir, num_samples=100):
     if forces:
         assert hasattr(sample, "neg_dy"), "Sample doesn't contain forces"
 
+    # Assert shapes of whole dataset:
+    for i in range(len(data)):
+        assert np.array(data[i].z).shape == (5,), "Dataset has incorrect atom numbers shape"
+        assert np.array(data[i].pos).shape == (5, 3), "Dataset has incorrect coords shape"
+        if energy:
+            assert np.array(data[i].y).shape == (1,), "Dataset has incorrect energy shape"
+        if forces:
+            assert np.array(data[i].neg_dy).shape == (5, 3), "Dataset has incorrect forces shape"
     # Assert sample has the correct values
 
     # get the reference values from coords_0.npy and embed_0.npy

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -62,6 +62,8 @@ class DataModule(LightningDataModule):
                 dataset_arg = {}
                 if self.hparams["dataset_arg"] is not None:
                     dataset_arg = self.hparams["dataset_arg"]
+                if self.hparams["dataset"] == "HD5F":
+                    dataset_arg["dataset_preload_limit"] = self.hparams["dataset_preload_limit"]
                 self.dataset = getattr(datasets, self.hparams["dataset"])(
                     self.hparams["dataset_root"], **dataset_arg
                 )

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -11,6 +11,7 @@ from torchmdnet.utils import make_splits, MissingEnergyException
 from torch_scatter import scatter
 from torchmdnet.models.utils import dtype_mapping
 
+
 class FloatCastDatasetWrapper(Dataset):
     def __init__(self, dataset, dtype=torch.float64):
         super(FloatCastDatasetWrapper, self).__init__(

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -55,6 +55,7 @@ class DataModule(LightningDataModule):
                     self.hparams["embed_files"],
                     self.hparams["energy_files"],
                     self.hparams["force_files"],
+                    self.hparams["dataset_preload_limit"],
                 )
             else:
                 dataset_arg = {}

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -61,7 +61,7 @@ class DataModule(LightningDataModule):
                 dataset_arg = {}
                 if self.hparams["dataset_arg"] is not None:
                     dataset_arg = self.hparams["dataset_arg"]
-                if self.hparams["dataset"] == "HD5F":
+                if self.hparams["dataset"] == "HDF5":
                     dataset_arg["dataset_preload_limit"] = self.hparams["dataset_preload_limit"]
                 self.dataset = getattr(datasets, self.hparams["dataset"])(
                     self.hparams["dataset_root"], **dataset_arg

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -20,6 +20,7 @@ class FloatCastDatasetWrapper(Dataset):
     """A wrapper around a torch_geometric dataset that casts all floating point
     tensors to a given dtype.
     """
+
     def __init__(self, dataset, dtype=torch.float64):
         super(FloatCastDatasetWrapper, self).__init__(
             dataset.root, dataset.transform, dataset.pre_transform, dataset.pre_filter
@@ -79,15 +80,16 @@ class DataModule(LightningDataModule):
                 if self.hparams["dataset_arg"] is not None:
                     dataset_arg = self.hparams["dataset_arg"]
                 if self.hparams["dataset"] == "HDF5":
-                    dataset_arg["dataset_preload_limit"] = self.hparams["dataset_preload_limit"]
+                    dataset_arg["dataset_preload_limit"] = self.hparams[
+                        "dataset_preload_limit"
+                    ]
                 self.dataset = getattr(datasets, self.hparams["dataset"])(
                     self.hparams["dataset_root"], **dataset_arg
                 )
 
-        if self.hparams["precision"] != 32:
-            self.dataset = FloatCastDatasetWrapper(
-                self.dataset, dtype_mapping[self.hparams["precision"]]
-            )
+        self.dataset = FloatCastDatasetWrapper(
+            self.dataset, dtype_mapping[self.hparams["precision"]]
+        )
 
         self.idx_train, self.idx_val, self.idx_test = make_splits(
             len(self.dataset),

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -56,6 +56,7 @@ class DataModule(LightningDataModule):
                     self.hparams["energy_files"],
                     self.hparams["force_files"],
                     self.hparams["dataset_preload_limit"],
+                    self.hparams["custom_read_as_hdf5"],
                 )
             else:
                 dataset_arg = {}

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -56,7 +56,6 @@ class DataModule(LightningDataModule):
                     self.hparams["energy_files"],
                     self.hparams["force_files"],
                     self.hparams["dataset_preload_limit"],
-                    self.hparams["custom_read_as_hdf5"],
                 )
             else:
                 dataset_arg = {}

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -113,7 +113,6 @@ class Custom(Dataset):
         print("Combined dataset size {}".format(len(self.index)))
         # If the dataset is small enough, load it whole into CPU memory
         data_size_limit = preload_memory_limit * 1024 * 1024
-        self.cache = False
         if total_data_size < data_size_limit:
             self.cached = True
             print(

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -17,7 +17,7 @@ class Custom(Dataset):
             (default: :obj:`None`)
         forceglob (string, optional): Glob path for force files. Stored as "neg_dy".
             (default: :obj:`None`)
-        load_into_memory_limit (int, optional): If the dataset is smaller than this limit (in MB), preload it into CPU memory.
+        preload_memory_limit (int, optional): If the dataset is smaller than this limit (in MB), preload it into CPU memory.
     Example:
         >>> data = Custom(coordglob="coords_files*npy", embedglob="embed_files*npy")
         >>> sample = data[0]

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -2,9 +2,6 @@ import glob
 import numpy as np
 import torch
 from torch_geometric.data import Dataset, Data
-from .hdf import HDF5
-import h5py
-import torch.distributed as dist
 
 __all__ = ["Custom"]
 

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -2,6 +2,38 @@ import glob
 import numpy as np
 import torch
 from torch_geometric.data import Dataset, Data
+from .hdf import HDF5
+import h5py
+
+__all__ = ["Custom"]
+
+
+def write_as_hdf5(coordfiles, embedfiles, energyfiles, forcefiles, hdf5_dataset):
+    """Transform the input to hdf5 format compatible with the HDF5 Dataset class.
+    The input files to the Custom dataset are transformed to a single HDF5 file.
+    Args:
+        coordfiles (list): List of coordinate files.
+        embedfiles (list): List of embedding files.
+        energyfiles (list): List of energy files.
+        forcefiles (list): List of force files.
+        hdf5_dataset (string): Path to the output HDF5 dataset.
+    """
+    with h5py.File(hdf5_dataset, "w") as f:
+        for i in range(len(coordfiles)):
+            # Create a group for each file
+            coord_data = np.load(coordfiles[i])
+            embed_data = np.load(embedfiles[i]).astype(int)
+            group = f.create_group(str(i))
+            num_samples = coord_data.shape[0]
+            group["pos"] = coord_data
+            group["types"] = np.tile(embed_data, (num_samples, 1))
+            if energyfiles is not None:
+                energy_data = np.load(energyfiles[i])
+                group["energy"] = energy_data
+            if forcefiles is not None:
+                force_data = np.load(forcefiles[i])
+                group["forces"] = force_data
+
 
 
 class Custom(Dataset):
@@ -18,6 +50,7 @@ class Custom(Dataset):
         forceglob (string, optional): Glob path for force files. Stored as "neg_dy".
             (default: :obj:`None`)
         preload_memory_limit (int, optional): If the dataset is smaller than this limit (in MB), preload it into CPU memory.
+        read_as_hdf5 (string, optional): If present, transform the input files to HDF5 format and use the HDF5 Dataset.
     Example:
         >>> data = Custom(coordglob="coords_files*npy", embedglob="embed_files*npy")
         >>> sample = data[0]
@@ -38,6 +71,7 @@ class Custom(Dataset):
         energyglob=None,
         forceglob=None,
         preload_memory_limit=1024,
+        read_as_hdf5=None,
     ):
         super(Custom, self).__init__()
         assert energyglob is not None or forceglob is not None, (
@@ -65,9 +99,52 @@ class Custom(Dataset):
                 f"Number of coordinate files {len(self.coordfiles)} "
                 f"does not match number of force files {len(self.forcefiles)}."
             )
-
         print("Number of files: ", len(self.coordfiles))
+        self.load_into_memory = False
+        if read_as_hdf5 is not None:
+            hdf5_file = read_as_hdf5
+            if not self.has_energies:
+                raise ValueError(
+                    "HDF5 format requires energies to be present in the dataset."
+                )
+            write_as_hdf5(
+                self.coordfiles,
+                self.embedfiles,
+                self.energyfiles,
+                self.forcefiles,
+                hdf5_file,
+            )
+            self.hdf5_dataset = HDF5(hdf5_file)
+        total_data_size = self._initialize_index()
+        print("Combined dataset size {}".format(len(self.index)))
+        # If the dataset is small enough, load it whole into CPU memory
+        data_size_limit = preload_memory_limit * 1024 * 1024
+        if total_data_size < data_size_limit:
+            self.load_into_memory = True
+            print(
+                "Preloading Custom dataset (of size {:.2f} MB) into CPU memory".format(
+                    total_data_size / 1024 / 1024
+                )
+            )
+            self._store_as_tensors()
 
+    def _store_as_tensors(self):
+        """Load the input files as Torch tensors.
+        """
+        self.coordfiles = torch.from_numpy(np.array([np.load(f) for f in self.coordfiles]))
+        self.embedfiles = torch.from_numpy(
+            np.array([np.load(f).astype(int) for f in self.embedfiles])
+        )
+        if self.has_energies:
+            self.energyfiles = torch.from_numpy(np.array([np.load(f) for f in self.energyfiles]))
+        if self.has_forces:
+            self.forcefiles = torch.from_numpy(np.array([np.load(f) for f in self.forcefiles]))
+
+    def _initialize_index(self):
+        """Initialize the index for the dataset.
+        Returns:
+            int: Total size of the dataset in bytes.
+        """
         # create index
         self.index = []
         nfiles = len(self.coordfiles)
@@ -98,33 +175,11 @@ class Custom(Dataset):
                     f"Data shape of coordinate file {i} {coord_data.shape} "
                     f"does not match the shape of force file {i} {force_data.shape}."
                 )
-        print("Combined dataset size {}".format(len(self.index)))
-        # If the dataset is small enough, load it whole into CPU memory
-        data_size_limit = preload_memory_limit * 1024 * 1024
-        self.load_into_memory = False
-        if total_data_size < data_size_limit:
-            self.load_into_memory = True
-            print(
-                "Preloading Custom dataset (of size {:.2f} MB) into CPU memory".format(
-                    total_data_size / 1024 / 1024
-                )
-            )
-            self.coordfiles = torch.from_numpy(
-                np.array([np.load(f) for f in self.coordfiles])
-            )
-            self.embedfiles = torch.from_numpy(
-                np.array([np.load(f).astype(int) for f in self.embedfiles])
-            )
-            if self.has_energies:
-                self.energyfiles = torch.from_numpy(
-                    np.array([np.load(f) for f in self.energyfiles])
-                )
-            if self.has_forces:
-                self.forcefiles = torch.from_numpy(
-                    np.array([np.load(f) for f in self.forcefiles])
-                )
+        return total_data_size
 
     def get(self, idx):
+        if hasattr(self, "hdf5_dataset"):
+            return self.hdf5_dataset.get(idx)
         fileid, index = self.index[idx]
         if self.load_into_memory:
             coord_data = self.coordfiles[fileid][index]

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -76,15 +76,13 @@ class Custom(Dataset):
         print("Number of files: ", len(self.files["pos"]))
         self.cached = False
         total_data_size = self._initialize_index()
-        print("Combined dataset size {}".format(len(self.index)))
+        print(f"Combined dataset size {len(self.index))}")
         # If the dataset is small enough, load it whole into CPU memory
         data_size_limit = preload_memory_limit * 1024 * 1024
         if total_data_size < data_size_limit:
             self.cached = True
             print(
-                "Preloading Custom dataset (of size {:.2f} MB)".format(
-                    total_data_size / 1024**2
-                )
+                f"Preloading Custom dataset (of size {total_data_size / 1024**2:.2f} MB)"
             )
             self._preload_data()
         else:

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -210,6 +210,8 @@ class Custom(Dataset):
         fileid, index = self.index[idx]
         data = Data()
         for field in self.fields:
+            # The dataset is stored as mem mapped numpy arrays unless it is cached,
+            # in which case it is already stored as torch tensors
             f = self.stored_data[field[0]][fileid][index]
             data[field[0]] = f if self.cached else torch.from_numpy(np.array(f))
         return data

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -31,7 +31,14 @@ class Custom(Dataset):
               - If present, "y" is an array of shape (1,) and "neg_dy" has shape (n_atoms, 3)
     """
 
-    def __init__(self, coordglob, embedglob, energyglob=None, forceglob=None, preload_memory_limit=1024):
+    def __init__(
+        self,
+        coordglob,
+        embedglob,
+        energyglob=None,
+        forceglob=None,
+        preload_memory_limit=1024,
+    ):
         super(Custom, self).__init__()
         assert energyglob is not None or forceglob is not None, (
             "Either energies, forces or both must " "be specified as the target"
@@ -64,7 +71,7 @@ class Custom(Dataset):
         # create index
         self.index = []
         nfiles = len(self.coordfiles)
-        total_data_size = 0 # Number of bytes in the dataset
+        total_data_size = 0  # Number of bytes in the dataset
         for i in range(nfiles):
             coord_data = np.load(self.coordfiles[i])
             embed_data = np.load(self.embedfiles[i]).astype(int)
@@ -97,14 +104,25 @@ class Custom(Dataset):
         self.load_into_memory = False
         if total_data_size < data_size_limit:
             self.load_into_memory = True
-            print("Preloading Custom dataset (of size {:.2f} MB) into CPU memory".format(total_data_size / 1024 / 1024))
-            self.coordfiles = torch.from_numpy(np.array([np.load(f) for f in self.coordfiles]))
-            self.embedfiles = torch.from_numpy(np.array([np.load(f).astype(int) for f in self.embedfiles]))
+            print(
+                "Preloading Custom dataset (of size {:.2f} MB) into CPU memory".format(
+                    total_data_size / 1024 / 1024
+                )
+            )
+            self.coordfiles = torch.from_numpy(
+                np.array([np.load(f) for f in self.coordfiles])
+            )
+            self.embedfiles = torch.from_numpy(
+                np.array([np.load(f).astype(int) for f in self.embedfiles])
+            )
             if self.has_energies:
-                self.energyfiles = torch.from_numpy(np.array([np.load(f) for f in self.energyfiles]))
+                self.energyfiles = torch.from_numpy(
+                    np.array([np.load(f) for f in self.energyfiles])
+                )
             if self.has_forces:
-                self.forcefiles = torch.from_numpy(np.array([np.load(f) for f in self.forcefiles]))
-
+                self.forcefiles = torch.from_numpy(
+                    np.array([np.load(f) for f in self.forcefiles])
+                )
 
     def get(self, idx):
         fileid, index = self.index[idx]
@@ -112,18 +130,20 @@ class Custom(Dataset):
             coord_data = self.coordfiles[fileid][index]
             embed_data = self.embedfiles[fileid]
         else:
-            coord_data = torch.from_numpy(np.array(np.load(self.coordfiles[fileid], mmap_mode="r")[index]))
+            coord_data = torch.from_numpy(
+                np.array(np.load(self.coordfiles[fileid], mmap_mode="r")[index])
+            )
             embed_data = torch.from_numpy(np.load(self.embedfiles[fileid]).astype(int))
 
-        features = dict(
-            pos=coord_data, z=embed_data
-        )
+        features = dict(pos=coord_data, z=embed_data)
 
         if self.has_energies and self.load_into_memory:
             energy_data = self.energyfiles[fileid][index]
             features["y"] = energy_data
         elif self.has_energies:
-            energy_data = torch.from_numpy(np.array(np.load(self.energyfiles[fileid], mmap_mode="r")[index]))
+            energy_data = torch.from_numpy(
+                np.array(np.load(self.energyfiles[fileid], mmap_mode="r")[index])
+            )
 
             features["y"] = energy_data
 

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -76,7 +76,7 @@ class Custom(Dataset):
         print("Number of files: ", len(self.files["pos"]))
         self.cached = False
         total_data_size = self._initialize_index()
-        print(f"Combined dataset size {len(self.index))}")
+        print(f"Combined dataset size {len(self.index)}")
         # If the dataset is small enough, load it whole into CPU memory
         data_size_limit = preload_memory_limit * 1024 * 1024
         if total_data_size < data_size_limit:

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -8,32 +8,28 @@ import h5py
 __all__ = ["Custom"]
 
 
-def write_as_hdf5(coordfiles, embedfiles, energyfiles, forcefiles, hdf5_dataset):
+def write_as_hdf5(files, hdf5_dataset):
     """Transform the input to hdf5 format compatible with the HDF5 Dataset class.
     The input files to the Custom dataset are transformed to a single HDF5 file.
     Args:
-        coordfiles (list): List of coordinate files.
-        embedfiles (list): List of embedding files.
-        energyfiles (list): List of energy files.
-        forcefiles (list): List of force files.
+        files (dict): Dictionary of input files. Must contain "pos", "z" and at least one of "y" or "neg_dy".
         hdf5_dataset (string): Path to the output HDF5 dataset.
     """
     with h5py.File(hdf5_dataset, "w") as f:
-        for i in range(len(coordfiles)):
+        for i in range(len(files["pos"])):
             # Create a group for each file
-            coord_data = np.load(coordfiles[i])
-            embed_data = np.load(embedfiles[i]).astype(int)
+            coord_data = np.load(files["pos"][i])
+            embed_data = np.load(files["z"][i]).astype(int)
             group = f.create_group(str(i))
             num_samples = coord_data.shape[0]
             group["pos"] = coord_data
             group["types"] = np.tile(embed_data, (num_samples, 1))
-            if energyfiles is not None:
-                energy_data = np.load(energyfiles[i])
+            if "y" in files:
+                energy_data = np.load(files["y"][i])
                 group["energy"] = energy_data
-            if forcefiles is not None:
-                force_data = np.load(forcefiles[i])
+            if "neg_dy" in files:
+                force_data = np.load(files["neg_dy"][i])
                 group["forces"] = force_data
-
 
 
 class Custom(Dataset):
@@ -79,39 +75,37 @@ class Custom(Dataset):
         )
         self.has_energies = energyglob is not None
         self.has_forces = forceglob is not None
-
-        self.coordfiles = sorted(glob.glob(coordglob))
-        self.embedfiles = sorted(glob.glob(embedglob))
-        self.energyfiles = sorted(glob.glob(energyglob)) if self.has_energies else None
-        self.forcefiles = sorted(glob.glob(forceglob)) if self.has_forces else None
-
-        assert len(self.coordfiles) == len(self.embedfiles), (
-            f"Number of coordinate files {len(self.coordfiles)} "
-            f"does not match number of embed files {len(self.embedfiles)}."
+        self.fields = [
+            ("pos", "pos", torch.float32),
+            ("z", "types", torch.long),
+        ]
+        self.files = {}
+        self.files["pos"] = sorted(glob.glob(coordglob))
+        self.files["z"] = sorted(glob.glob(embedglob))
+        assert len(self.files["pos"]) == len(self.files["z"]), (
+            f"Number of coordinate files {len(self.files['pos'])} "
+            f"does not match number of embed files {len(self.files['z'])}."
         )
         if self.has_energies:
-            assert len(self.coordfiles) == len(self.energyfiles), (
-                f"Number of coordinate files {len(self.coordfiles)} "
-                f"does not match number of energy files {len(self.energyfiles)}."
+            self.files["y"] = sorted(glob.glob(energyglob))
+            self.fields.append(("y", "energy", torch.float32))
+            assert len(self.files["pos"]) == len(self.files["y"]), (
+                f"Number of coordinate files {len(self.files['pos'])} "
+                f"does not match number of energy files {len(self.files['y'])}."
             )
         if self.has_forces:
-            assert len(self.coordfiles) == len(self.forcefiles), (
-                f"Number of coordinate files {len(self.coordfiles)} "
-                f"does not match number of force files {len(self.forcefiles)}."
+            self.files["neg_dy"] = sorted(glob.glob(forceglob))
+            self.fields.append(("neg_dy", "forces", torch.float32))
+            assert len(self.files["pos"]) == len(self.files["neg_dy"]), (
+                f"Number of coordinate files {len(self.files['pos'])} "
+                f"does not match number of force files {len(self.files['neg_dy'])}."
             )
-        print("Number of files: ", len(self.coordfiles))
-        self.load_into_memory = False
+        print("Number of files: ", len(self.files["pos"]))
+        self.cached = False
         if read_as_hdf5 is not None:
             hdf5_file = read_as_hdf5
-            if not self.has_energies:
-                raise ValueError(
-                    "HDF5 format requires energies to be present in the dataset."
-                )
             write_as_hdf5(
-                self.coordfiles,
-                self.embedfiles,
-                self.energyfiles,
-                self.forcefiles,
+                self.files,
                 hdf5_file,
             )
             self.hdf5_dataset = HDF5(hdf5_file)
@@ -119,57 +113,90 @@ class Custom(Dataset):
         print("Combined dataset size {}".format(len(self.index)))
         # If the dataset is small enough, load it whole into CPU memory
         data_size_limit = preload_memory_limit * 1024 * 1024
+        self.cache = False
         if total_data_size < data_size_limit:
-            self.load_into_memory = True
+            self.cached = True
             print(
-                "Preloading Custom dataset (of size {:.2f} MB) into CPU memory".format(
-                    total_data_size / 1024 / 1024
+                "Preloading Custom dataset (of size {:.2f} MB)".format(
+                    total_data_size / 1024**2
                 )
             )
-            self._store_as_tensors()
+            self._preload_data()
+        else:
+            self._store_numpy_memmaps()
 
-    def _store_as_tensors(self):
+    def _preload_data(self):
         """Load the input files as Torch tensors.
+        Each file can have different number of atoms, so each one is stored in a different tensor.
         """
-        self.coordfiles = torch.from_numpy(np.array([np.load(f) for f in self.coordfiles]))
-        self.embedfiles = torch.from_numpy(
-            np.array([np.load(f).astype(int) for f in self.embedfiles])
-        )
+        self.stored_data = {}
+        self.stored_data["pos"] = [
+            torch.from_numpy(np.load(f)) for f in self.files["pos"]
+        ]
+        self.stored_data["z"] = [
+            torch.from_numpy(np.load(f).astype(int))
+            .unsqueeze(0)
+            .expand(self.stored_data["pos"][i].shape[0], -1)
+            for i, f in enumerate(self.files["z"])
+        ]
         if self.has_energies:
-            self.energyfiles = torch.from_numpy(np.array([np.load(f) for f in self.energyfiles]))
+            self.stored_data["y"] = [
+                torch.from_numpy(np.load(f)) for f in self.files["y"]
+            ]
         if self.has_forces:
-            self.forcefiles = torch.from_numpy(np.array([np.load(f) for f in self.forcefiles]))
+            self.stored_data["neg_dy"] = [
+                torch.from_numpy(np.load(f)) for f in self.files["neg_dy"]
+            ]
+
+    def _store_numpy_memmaps(self):
+        """Create a dictionary with numpy arrays with mmap_mode="r" for each file."""
+        self.stored_data = {}
+        self.stored_data["pos"] = [np.load(f, mmap_mode="r") for f in self.files["pos"]]
+        self.stored_data["z"] = []
+        for i, f in enumerate(self.files["z"]):
+            loaded_data = np.load(f).astype(int)
+            desired_shape = (len(self.stored_data["pos"][i]), loaded_data.shape[0])
+            broadcasted_data = np.broadcast_to(
+                loaded_data[np.newaxis, :], desired_shape
+            )
+            self.stored_data["z"].append(broadcasted_data)
+        if self.has_energies:
+            self.stored_data["y"] = [np.load(f, mmap_mode="r") for f in self.files["y"]]
+        if self.has_forces:
+            self.stored_data["neg_dy"] = [
+                np.load(f, mmap_mode="r") for f in self.files["neg_dy"]
+            ]
 
     def _initialize_index(self):
         """Initialize the index for the dataset.
+        The index relates a sample to the file it belongs to and the index within that file.
         Returns:
             int: Total size of the dataset in bytes.
         """
         # create index
         self.index = []
-        nfiles = len(self.coordfiles)
+        nfiles = len(self.files["pos"])
         total_data_size = 0  # Number of bytes in the dataset
         for i in range(nfiles):
-            coord_data = np.load(self.coordfiles[i])
-            embed_data = np.load(self.embedfiles[i]).astype(int)
+            coord_data = np.load(self.files["pos"][i], mmap_mode="r")
+            embed_data = np.load(self.files["z"][i]).astype(int)
             size = coord_data.shape[0]
             total_data_size += coord_data.nbytes + embed_data.nbytes
             self.index.extend(list(zip([i] * size, range(size))))
-
             # consistency check
             assert coord_data.shape[1] == embed_data.shape[0], (
                 f"Number of atoms in coordinate file {i} ({coord_data.shape[1]}) "
                 f"does not match number of atoms in embed file {i} ({embed_data.shape[0]})."
             )
             if self.has_energies:
-                energy_data = np.load(self.energyfiles[i])
+                energy_data = np.load(self.files["y"][i], mmap_mode="r")
                 total_data_size += energy_data.nbytes
                 assert coord_data.shape[0] == energy_data.shape[0], (
                     f"Number of frames in coordinate file {i} ({coord_data.shape[0]}) "
                     f"does not match number of frames in energy file {i} ({energy_data.shape[0]})."
                 )
             if self.has_forces:
-                force_data = np.load(self.forcefiles[i])
+                force_data = np.load(self.files["neg_dy"][i], mmap_mode="r")
                 total_data_size += force_data.nbytes
                 assert coord_data.shape == force_data.shape, (
                     f"Data shape of coordinate file {i} {coord_data.shape} "
@@ -181,37 +208,11 @@ class Custom(Dataset):
         if hasattr(self, "hdf5_dataset"):
             return self.hdf5_dataset.get(idx)
         fileid, index = self.index[idx]
-        if self.load_into_memory:
-            coord_data = self.coordfiles[fileid][index]
-            embed_data = self.embedfiles[fileid]
-        else:
-            coord_data = torch.from_numpy(
-                np.array(np.load(self.coordfiles[fileid], mmap_mode="r")[index])
-            )
-            embed_data = torch.from_numpy(np.load(self.embedfiles[fileid]).astype(int))
-
-        features = dict(pos=coord_data, z=embed_data)
-
-        if self.has_energies and self.load_into_memory:
-            energy_data = self.energyfiles[fileid][index]
-            features["y"] = energy_data
-        elif self.has_energies:
-            energy_data = torch.from_numpy(
-                np.array(np.load(self.energyfiles[fileid], mmap_mode="r")[index])
-            )
-
-            features["y"] = energy_data
-
-        if self.has_forces and self.load_into_memory:
-            force_data = self.forcefiles[fileid][index]
-            features["neg_dy"] = force_data
-        elif self.has_forces:
-            force_data = torch.from_numpy(
-                np.array(np.load(self.forcefiles[fileid], mmap_mode="r")[index])
-            )
-            features["neg_dy"] = force_data
-
-        return Data(**features)
+        data = Data()
+        for field in self.fields:
+            f = self.stored_data[field[0]][fileid][index]
+            data[field[0]] = f if self.cached else torch.from_numpy(np.array(f))
+        return data
 
     def len(self):
         return len(self.index)

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -18,17 +18,17 @@ def write_as_hdf5(files, hdf5_dataset):
     with h5py.File(hdf5_dataset, "w") as f:
         for i in range(len(files["pos"])):
             # Create a group for each file
-            coord_data = np.load(files["pos"][i])
-            embed_data = np.load(files["z"][i]).astype(int)
+            coord_data = np.load(files["pos"][i], mmap_mode="r")
+            embed_data = np.load(files["z"][i], mmap_mode="r").astype(int)
             group = f.create_group(str(i))
             num_samples = coord_data.shape[0]
             group["pos"] = coord_data
             group["types"] = np.tile(embed_data, (num_samples, 1))
             if "y" in files:
-                energy_data = np.load(files["y"][i])
+                energy_data = np.load(files["y"][i], mmap_mode="r")
                 group["energy"] = energy_data
             if "neg_dy" in files:
-                force_data = np.load(files["neg_dy"][i])
+                force_data = np.load(files["neg_dy"][i], mmap_mode="r")
                 group["forces"] = force_data
 
 

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -22,14 +22,14 @@ def write_as_hdf5(files, hdf5_dataset):
             embed_data = np.load(files["z"][i], mmap_mode="r").astype(int)
             group = f.create_group(str(i))
             num_samples = coord_data.shape[0]
-            group["pos"] = coord_data
-            group["types"] = np.tile(embed_data, (num_samples, 1))
+            group.create_dataset("pos", data=coord_data)
+            group.create_dataset("types", data=np.tile(embed_data, (num_samples, 1)))
             if "y" in files:
                 energy_data = np.load(files["y"][i], mmap_mode="r")
-                group["energy"] = energy_data
+                group.create_dataset("energy", data=energy_data)
             if "neg_dy" in files:
                 force_data = np.load(files["neg_dy"][i], mmap_mode="r")
-                group["forces"] = force_data
+                group.create_dataset("forces", data=force_data)
 
 
 class Custom(Dataset):

--- a/torchmdnet/datasets/hdf.py
+++ b/torchmdnet/datasets/hdf.py
@@ -18,72 +18,109 @@ class HDF5(Dataset):
 
     Args:
         filename (string): A semicolon separated list of HDF5 files.
+        dataset_preload_limit (int, optional): If the dataset is smaller than this limit (in MB), preload it into CPU memory. (default: :obj:`1024`)
+
     """
 
-    def __init__(self, filename, **kwargs):
+    def __init__(self, filename, dataset_preload_limit=1024, **kwargs):
         super(HDF5, self).__init__()
         self.filename = filename
         self.index = None
         self.fields = None
         self.num_molecules = 0
         files = [h5py.File(f, "r") for f in self.filename.split(";")]
+        total_file_size = sum([f.id.get_filesize() for f in files])
+        print(f"Loading {len(files)} HDF5 files ({total_file_size / 1024**2:.2f} MB)")
         for file in files:
             for group_name in file:
                 group = file[group_name]
-                if group_name == '_metadata':
+                if group_name == "_metadata":
                     for name in group:
                         setattr(self, name, torch.tensor(np.array(group[name])))
                 else:
-                    self.num_molecules += len(group["energy"])
+                    self.num_molecules += len(group["pos"])
                     if self.fields is None:
                         # Record which data fields are present in this file.
                         self.fields = [
-                            ('pos', 'pos', torch.float32),
-                            ('z', 'types', torch.long),
-                            ('y', 'energy', torch.float32)
+                            ("pos", "pos", torch.float32),
+                            ("z", "types", torch.long),
                         ]
-                        if 'forces' in group:
-                            self.fields.append(('neg_dy', 'forces', torch.float32))
-                        if 'partial_charges' in group:
-                            self.fields.append(('partial_charges', 'partial_charges', torch.float32))
+                        if "energy" in group:
+                            self.fields.append(("y", "energy", torch.float32))
+                        if "forces" in group:
+                            self.fields.append(("neg_dy", "forces", torch.float32))
+                        if "partial_charges" in group:
+                            self.fields.append(
+                                ("partial_charges", "partial_charges", torch.float32)
+                            )
                         assert ("energy" in group) or (
                             "forces" in group
                         ), "Each group must contain at least energies or forces"
             file.close()
+        self.cached = False
+        if total_file_size <= dataset_preload_limit * 1024**2:
+            print(
+                f"Preloading {len(files)} HDF5 files ({total_file_size / 1024**2:.2f} MB)"
+            )
+            self.cached = True
+            self._preload_data()
 
-    def setup_index(self):
+    def _preload_data(self):
+        """Preload the entire dataset into memory.
+        Store it in a dictionary of torch tensors. The dictionary has an entry for each field and group.
+        """
+        self.stored_data = {}
+        for field in self.fields:
+            self.stored_data[field] = []
+        self.index = []
         files = [h5py.File(f, "r") for f in self.filename.split(";")]
-        self.has_forces = False
+        i = 0
+        for file in files:
+            for group_name, group in file.items():
+                if group_name != "_metadata":
+                    size = len(group["pos"])
+                    for field in self.fields:
+                        data = group[field[1]]
+                        dtype = field[2]
+                        # Watchout for the 1D case, embed can be shared for all samples
+                        tmp = torch.tensor(np.array(data), dtype=dtype)
+                        if tmp.ndim == 1:
+                            tmp = tmp.unsqueeze(0).expand(size, -1)
+                        self.stored_data[field].append(tmp)
+                    self.index.extend(list(zip([i] * size, range(size))))
+                    i += 1
+            file.close()
+
+    def _setup_index(self):
+        files = [h5py.File(f, "r") for f in self.filename.split(";")]
         self.index = []
         for file in files:
-            for group_name in file:
-                if group_name != '_metadata':
-                    group = file[group_name]
-                    data = tuple(group[field[1]] for field in self.fields)
-                    energy = group['energy']
-                    for i in range(len(energy)):
-                        self.index.append(data+(i,))
-
-        assert self.num_molecules == len(self.index), (
-            "Mismatch between previously calculated "
-            "molecule count and actual molecule count"
-        )
+            for group_name, group in file.items():
+                if group_name != "_metadata":
+                    data = [group[field[1]] for field in self.fields]
+                    self.index.extend(
+                        [tuple(data + [i]) for i in range(len(group["pos"]))]
+                    )
+        assert self.num_molecules == len(
+            self.index
+        ), f"Mismatch between previously calculated molecule count ({self.num_molecules}) and actual molecule count ({len(self.index)})"
 
     def get(self, idx):
-        # only open files here to avoid copying objects of this class to another
-        # process with open file handles (potentially corrupts h5py loading)
-        if self.index is None:
-            self.setup_index()
-
-        entry = self.index[idx]
-        i = entry[-1]
         data = Data()
-        for j, field in enumerate(self.fields):
-            d = entry[j]
-            if d.ndim == 1:
-                data[field[0]] = torch.tensor([[d[i]]], dtype=field[2])
-            else:
-                data[field[0]] = torch.from_numpy(d[i]).to(field[2])
+        if self.cached:
+            # If the dataset is cached, the index is just a list of indices into the stored data.
+            fileid, index = self.index[idx]
+            for field in self.fields:
+                data[field[0]] = self.stored_data[field][fileid][index]
+        else:
+            # only open files here to avoid copying objects of this class to another
+            # process with open file handles (potentially corrupts h5py loading)
+            if self.index is None:
+                self._setup_index()
+            *fields_data, i = self.index[idx]
+            for (name, _, dtype), d in zip(self.fields, fields_data):
+                tensor_input = [[d[i]]] if d.ndim == 1 else d[i]
+                data[name] = torch.tensor(tensor_input, dtype=dtype)
         return data
 
     def len(self):

--- a/torchmdnet/datasets/hdf.py
+++ b/torchmdnet/datasets/hdf.py
@@ -7,13 +7,14 @@ import numpy as np
 class HDF5(Dataset):
     """A custom dataset that loads data from a HDF5 file.
 
-    To use this, dataset_root should be the path to the HDF5 file, or alternatively
-    a semicolon separated list of multiple files.  Each group in the file contains
-    samples that all have the same number of atoms.  Typically there is one
-    group for each unique number of atoms, but that is not required.  Each group
-    should contain arrays called "types" (atom type indices), "pos" (atom positions),
-    and "energy" (the energy of each sample).  It may optionally include an array
-    called "forces" (the force on each atom).
+    To use this, dataset_root should be  the path to the HDF5 file, or
+    alternatively a semicolon separated  list of multiple files.  Each
+    group in the  file contains samples that all have  the same number
+    of atoms.  Typically there is one  group for each unique number of
+    atoms, but that is not required.  Each group should contain arrays
+    called "types" (atom type indices), "pos" (atom positions), and at
+    least one of "energy" (the  energy of each sample) and/or "forces"
+    (the force on each atom).
 
     Args:
         filename (string): A semicolon separated list of HDF5 files.
@@ -45,6 +46,9 @@ class HDF5(Dataset):
                             self.fields.append(('neg_dy', 'forces', torch.float32))
                         if 'partial_charges' in group:
                             self.fields.append(('partial_charges', 'partial_charges', torch.float32))
+                        assert ("energy" in group) or (
+                            "forces" in group
+                        ), "Each group must contain at least energies or forces"
             file.close()
 
     def setup_index(self):

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -61,7 +61,7 @@ def get_args():
     parser.add_argument('--embed-files', default=None, type=str, help='Custom embedding files glob')
     parser.add_argument('--energy-files', default=None, type=str, help='Custom energy files glob')
     parser.add_argument('--force-files', default=None, type=str, help='Custom force files glob')
-    parser.add_argument('--dataset-preload-limit', default=1024, type=int, help='Custom dataset will preload to RAM datasets that are less than this size in MB')
+    parser.add_argument('--dataset-preload-limit', default=1024, type=int, help='Custom and HDF5 datasets will preload to RAM datasets that are less than this size in MB')
     parser.add_argument('--custom-read-as-hdf5', default=None, type=str, help='If present, Custom will transform the input files to HDF5 format and use the HDF5 Dataset. The argument is the path to the created HDF5 dataset')
     parser.add_argument('--y-weight', default=1.0, type=float, help='Weighting factor for y label in the loss function')
     parser.add_argument('--neg-dy-weight', default=1.0, type=float, help='Weighting factor for neg_dy label in the loss function')

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -62,7 +62,7 @@ def get_args():
     parser.add_argument('--energy-files', default=None, type=str, help='Custom energy files glob')
     parser.add_argument('--force-files', default=None, type=str, help='Custom force files glob')
     parser.add_argument('--dataset-preload-limit', default=1024, type=int, help='Custom dataset will preload to RAM datasets that are less than this size in MB')
-
+    parser.add_argument('--custom-read-as-hdf5', default=None, type=str, help='If present, Custom will transform the input files to HDF5 format and use the HDF5 Dataset. The argument is the path to the created HDF5 dataset')
     parser.add_argument('--y-weight', default=1.0, type=float, help='Weighting factor for y label in the loss function')
     parser.add_argument('--neg-dy-weight', default=1.0, type=float, help='Weighting factor for neg_dy label in the loss function')
 

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -61,6 +61,8 @@ def get_args():
     parser.add_argument('--embed-files', default=None, type=str, help='Custom embedding files glob')
     parser.add_argument('--energy-files', default=None, type=str, help='Custom energy files glob')
     parser.add_argument('--force-files', default=None, type=str, help='Custom force files glob')
+    parser.add_argument('--dataset-preload-limit', default=1024, type=int, help='Custom dataset will preload to RAM datasets that are less than this size in MB')
+
     parser.add_argument('--y-weight', default=1.0, type=float, help='Weighting factor for y label in the loss function')
     parser.add_argument('--neg-dy-weight', default=1.0, type=float, help='Weighting factor for neg_dy label in the loss function')
 

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -62,7 +62,6 @@ def get_args():
     parser.add_argument('--energy-files', default=None, type=str, help='Custom energy files glob')
     parser.add_argument('--force-files', default=None, type=str, help='Custom force files glob')
     parser.add_argument('--dataset-preload-limit', default=1024, type=int, help='Custom and HDF5 datasets will preload to RAM datasets that are less than this size in MB')
-    parser.add_argument('--custom-read-as-hdf5', default=None, type=str, help='If present, Custom will transform the input files to HDF5 format and use the HDF5 Dataset. The argument is the path to the created HDF5 dataset')
     parser.add_argument('--y-weight', default=1.0, type=float, help='Weighting factor for y label in the loss function')
     parser.add_argument('--neg-dy-weight', default=1.0, type=float, help='Weighting factor for neg_dy label in the loss function')
 

--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -217,3 +217,34 @@ def number(text):
 
 class MissingEnergyException(Exception):
     pass
+
+def write_as_hdf5(files, hdf5_dataset):
+    """Transform the input numpy files to hdf5 format compatible with the HDF5 Dataset class.
+    The input files to this function are the same as the ones required by the Custom dataset.
+    Args:
+        files (dict): Dictionary of numpy input files. Must contain "pos", "z" and at least one of "y" or "neg_dy".
+        hdf5_dataset (string): Path to the output HDF5 dataset.
+    Example:
+        >>> files = {}
+        >>> files["pos"] = sorted(glob.glob(join(tmpdir, "coords*")))
+        >>> files["z"] = sorted(glob.glob(join(tmpdir, "embed*")))
+        >>> files["y"] = sorted(glob.glob(join(tmpdir, "energy*")))
+        >>> files["neg_dy"] = sorted(glob.glob(join(tmpdir, "forces*")))
+        >>> write_as_hdf5(files, join(tmpdir, "test.hdf5"))
+    """
+    import h5py
+    with h5py.File(hdf5_dataset, "w") as f:
+        for i in range(len(files["pos"])):
+            # Create a group for each file
+            coord_data = np.load(files["pos"][i], mmap_mode="r")
+            embed_data = np.load(files["z"][i], mmap_mode="r").astype(int)
+            group = f.create_group(str(i))
+            num_samples = coord_data.shape[0]
+            group.create_dataset("pos", data=coord_data)
+            group.create_dataset("types", data=np.tile(embed_data, (num_samples, 1)))
+            if "y" in files:
+                energy_data = np.load(files["y"][i], mmap_mode="r")
+                group.create_dataset("energy", data=energy_data)
+            if "neg_dy" in files:
+                force_data = np.load(files["neg_dy"][i], mmap_mode="r")
+                group.create_dataset("forces", data=force_data)


### PR DESCRIPTION
While replicating results from the [torchmd-protein-thermodynamics repository](https://github.com/torchmd/torchmd-protein-thermodynamics), I experienced sluggish training speeds and low GPU usage (meaning sitting at 0% and briefly going to 100% at each iteration) using the following configuration file:
```yaml
activation: tanh
batch_size: 1024
inference_batch_size: 1024
dataset: Custom
coord_files: "chignolin_ca_coords.npy"
embed_files: "chignolin_ca_embeddings.npy"
force_files: "chignolin_ca_deltaforces.npy"
cutoff_upper: 12.0
cutoff_lower: 3.0
derivative: true
early_stopping_patience: 30
embedding_dimension: 128
lr: 0.0005
lr_factor: 0.8
lr_min: 1.0e-06
lr_patience: 10
lr_warmup_steps: 0
model: graph-network
neighbor_embedding: false
ngpus: -1
num_epochs: 100
num_layers: 4
num_nodes: 1
num_rbf: 18
num_workers: 4
rbf_type: expnorm
save_interval: 2
seed: 1
test_interval: 2
test_size: 0.1
trainable_rbf: true
val_size: 0.05
weight_decay: 0.0
```
The referenced files take approx 300mb.
Playing around with num_workers and batch size did not help.
Upon investigation, the issue arose from the Custom dataset's I/O-bound get method, which reads from disk every time it is invoked, causing the low GPU usage and slow training.

To resolve this, I implemented a preloading feature that loads the complete dataset into system memory if its size is below a user-configurable threshold, set by default at 1GB. The data is stored as PyTorch tensors, facilitating compatibility with multi-threaded data loaders (num_workers). Notably, this approach does not inflate RAM usage when increasing the number of workers.

This optimization led to a x20 speedup in training time for this specific setup.

OTOH I tweaked the DataLoader options a bit.
