### PR TITLE
Adding vector feature cutoff to ET

### DIFF
--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -36,6 +36,9 @@ def create_model(args, prior_model=None, mean=None, std=None):
         args["check_errors"] = True
     if "static_shapes" not in args:
         args["static_shapes"] = False
+    if "et_vector_cutoff" not in args:
+        args["et_vector_cutoff"] = False
+
     shared_args = dict(
         hidden_channels=args["embedding_dimension"],
         num_layers=args["num_layers"],
@@ -85,6 +88,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
             num_heads=args["num_heads"],
             distance_influence=args["distance_influence"],
             neighbor_embedding=args["neighbor_embedding"],
+            vector_cutoff=args["et_vector_cutoff"],
             **shared_args,
         )
     elif args["model"] == "tensornet":

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -36,8 +36,8 @@ def create_model(args, prior_model=None, mean=None, std=None):
         args["check_errors"] = True
     if "static_shapes" not in args:
         args["static_shapes"] = False
-    if "et_vector_cutoff" not in args:
-        args["et_vector_cutoff"] = False
+    if "vector_cutoff" not in args:
+        args["vector_cutoff"] = False
 
     shared_args = dict(
         hidden_channels=args["embedding_dimension"],
@@ -88,7 +88,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
             num_heads=args["num_heads"],
             distance_influence=args["distance_influence"],
             neighbor_embedding=args["neighbor_embedding"],
-            vector_cutoff=args["et_vector_cutoff"],
+            vector_cutoff=args["vector_cutoff"],
             **shared_args,
         )
     elif args["model"] == "tensornet":

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -301,14 +301,20 @@ class EquivariantMultiHeadAttention(nn.Module):
     def reset_parameters(self):
         self.layernorm.reset_parameters()
         nn.init.xavier_uniform_(self.q_proj.weight)
+        self.q_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.k_proj.weight)
+        self.k_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.v_proj.weight)
+        self.v_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.o_proj.weight)
+        self.o_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.vec_proj.weight)
         if self.dk_proj:
             nn.init.xavier_uniform_(self.dk_proj.weight)
+            self.dk_proj.bias.data.fill_(0)
         if self.dv_proj:
             nn.init.xavier_uniform_(self.dv_proj.weight)
+            self.dv_proj.bias.data.fill_(0)
 
     def forward(self, x, vec, edge_index, r_ij, f_ij, d_ij):
         x = self.layernorm(x)

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -15,7 +15,6 @@ from torchmdnet.models.utils import (
 )
 from torchmdnet.utils import deprecated_class
 
-@deprecated_class
 class TorchMD_ET(nn.Module):
     r"""Equivariant Transformer's architecture. From
     Equivariant Transformers for Neural Network based Molecular Potentials; P. Tholke and G. de Fabritiis.

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -14,7 +14,7 @@ from torchmdnet.models.utils import (
     scatter,
 )
 
-
+@deprecated_class
 class TorchMD_ET(nn.Module):
     r"""Equivariant Transformer's architecture. From
     Equivariant Transformers for Neural Network based Molecular Potentials; P. Tholke and G. de Fabritiis.

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -301,20 +301,14 @@ class EquivariantMultiHeadAttention(nn.Module):
     def reset_parameters(self):
         self.layernorm.reset_parameters()
         nn.init.xavier_uniform_(self.q_proj.weight)
-        self.q_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.k_proj.weight)
-        self.k_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.v_proj.weight)
-        self.v_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.o_proj.weight)
-        self.o_proj.bias.data.fill_(0)
         nn.init.xavier_uniform_(self.vec_proj.weight)
         if self.dk_proj:
             nn.init.xavier_uniform_(self.dk_proj.weight)
-            self.dk_proj.bias.data.fill_(0)
         if self.dv_proj:
             nn.init.xavier_uniform_(self.dv_proj.weight)
-            self.dv_proj.bias.data.fill_(0)
 
     def forward(self, x, vec, edge_index, r_ij, f_ij, d_ij):
         x = self.layernorm(x)

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -13,6 +13,7 @@ from torchmdnet.models.utils import (
     act_class_mapping,
     scatter,
 )
+from torchmdnet.utils import deprecated_class
 
 @deprecated_class
 class TorchMD_ET(nn.Module):

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -76,6 +76,8 @@ class TorchMD_ET(nn.Module):
             where `box_vectors[0] = a`, `box_vectors[1] = b`, and `box_vectors[2] = c`.
             If this is omitted, periodic boundary conditions are not applied.
             (default: :obj:`None`)
+        vector_cutoff (bool, optional): Whether to apply the cutoff to the vector features. This prevents the energy from being discontinuous at the cutoff, but may hinder training.
+            (default: :obj:`False`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
 
@@ -99,6 +101,7 @@ class TorchMD_ET(nn.Module):
         max_num_neighbors=32,
         check_errors=True,
         box_vecs=None,
+        vector_cutoff=False,
         dtype=torch.float32,
     ):
         super(TorchMD_ET, self).__init__()
@@ -168,6 +171,7 @@ class TorchMD_ET(nn.Module):
                 attn_activation,
                 cutoff_lower,
                 cutoff_upper,
+                vector_cutoff,
                 dtype,
             )
             self.attention_layers.append(layer)
@@ -255,6 +259,7 @@ class EquivariantMultiHeadAttention(nn.Module):
         attn_activation,
         cutoff_lower,
         cutoff_upper,
+        vector_cutoff=False,
         dtype=torch.float32,
     ):
         super(EquivariantMultiHeadAttention, self).__init__()
@@ -289,6 +294,7 @@ class EquivariantMultiHeadAttention(nn.Module):
         self.dv_proj = None
         if distance_influence in ["values", "both"]:
             self.dv_proj = nn.Linear(num_rbf, hidden_channels * 3, dtype=dtype)
+        self.vector_cutoff = vector_cutoff
 
         self.reset_parameters()
 
@@ -388,8 +394,17 @@ class EquivariantMultiHeadAttention(nn.Module):
             attn = (q_i * k_j * dk).sum(dim=-1)
 
         # attention activation function
-        attn = self.attn_activation(attn) * self.cutoff(r_ij).unsqueeze(1)
+        cutoff = self.cutoff(r_ij).unsqueeze(1)
+        attn = self.attn_activation(attn)
 
+        # The original ET arquitecture only weights the attention with the cutoff function,
+        #  this causes a discontinuity in the energy at the cutoff, since the bias of the dv_proj
+        #  layer might be non-zero.
+        # This option makes it so that both the scalar and vector features are weighted with the cutoff.
+        if self.vector_cutoff:
+            v_j = v_j * cutoff.unsqueeze(2)
+        else:
+            attn = attn * cutoff
         # value pathway
         if dv is not None:
             v_j = v_j * dv

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -93,6 +93,9 @@ def get_argparse():
     parser.add_argument('--attn-activation', default='silu', choices=list(act_class_mapping.keys()), help='Attention activation function')
     parser.add_argument('--num-heads', type=int, default=8, help='Number of attention heads')
 
+    # Equivariant Transformer specific
+    parser.add_argument('--vector-cutoff', type=bool, default=False, help='If true, the vector features are weighted by the cutoff function during message passing, forcing the energy to be continuous at the cutoff.')
+
     # TensorNet specific
     parser.add_argument('--equivariance-invariance-group', type=str, default='O(3)', help='Equivariance and invariance group of TensorNet')
     parser.add_argument('--box-vecs', type=lambda x: list(yaml.safe_load(x)), default=None, help="""Box vectors for periodic boundary conditions. The vectors `a`, `b`, and `c` represent a triclinic box and must satisfy


### PR DESCRIPTION
The user in #254 discovered a discontinuity in the energy at the cutoff when using ET.
We found that this is caused by a quirk in the current architecture that cannot be avoided without invalidating previous checkpoints.

The message passing step in the current architecture, which is consistent with eq. 9 in [1], weights only scalar features with the cutoff function, not vector ones. Given that both distance projections (eq. 5) have a bias, this allows the arch to learn a non-vanishing offset on the energy.

We can solve this by modifying the message passing so that the cutoff also affects vector features. This amounts to taking away the $\phi(d_{ij})$ from eq. 8 and multiplying it instead at eq.9a, so that $s^1_{ij}, s^2_{ij}, s^3_{ij} = \text{split}(V_j\odot D^V_{ij}) \phi(d_{ij})$.

Since this invalidates checkpoints I am gating this change behind a new option, `vector_cutoff`, that defaults to false and if turned on implements this new behavior.

Enabling this option seems to slightly improve benchmarks, for instance, this is ET-MD17.yaml with and without (reference) vector_cutoff. Note that I did not do any kind of hparam optimization.
![image](https://github.com/torchmd/torchmd-net/assets/13015792/df8d7f96-1272-4f77-9f63-b98083d22ed9)

Moreover, since we are moving away from ET in general in favor of TensorNet, I am using this PR to mark ET as deprecated.


[1] https://arxiv.org/pdf/2202.02541.pdf

Closes #254 