### PR TITLE
Unique COMP6 GDB molecule IDs

### DIFF
--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -8,6 +8,7 @@ import torch as pt
 from torch_geometric.data import Data, Dataset, download_url
 from torchmdnet.datasets.memdataset import MemmappedDataset
 from tqdm import tqdm
+import os
 
 """
 COmprehensive Machine-learning Potential (COMP6) Benchmark Suite
@@ -98,7 +99,7 @@ class COMP6Base(MemmappedDataset):
                     # Create a sample
                     args = dict(z=z, pos=pos, y=y.view(1, 1), neg_dy=neg_dy)
                     if mol_ids:
-                        args["mol_id"] = mol_id
+                        args["mol_id"] = f"{os.path.basename(path)}_{mol_id}"
                     data = Data(**args)
 
                     if self.pre_filter is not None and not self.pre_filter(data):


### PR DESCRIPTION
Tiny fix.

The molecule ids were not unique without the name of the file (they are repeated in different files of the same dataset) and it was causing issues in the evaluation when calculating relative conformer energies.