### PR TITLE
Fix for COMP6v1 forces

### DIFF
--- a/tests/test_dataset_comp6.py
+++ b/tests/test_dataset_comp6.py
@@ -42,7 +42,7 @@ def test_dataset_s66x8():
         assert pt.allclose(sample.y, pt.tensor([[-47.5919]]))
         assert pt.allclose(
             sample.neg_dy,
-            pt.tensor(
+            -pt.tensor(
                 [
                     [0.2739, -0.2190, -0.0012],
                     [-0.2938, 0.0556, -0.0023],

--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -86,6 +86,9 @@ class COMP6Base(MemmappedDataset):
                 all_neg_dy = pt.tensor(
                     mol["forces"][:] * self.HARTREE_TO_EV, dtype=pt.float32
                 )
+                all_neg_dy = (
+                    -all_neg_dy
+                )  # The COMP6 datasets accidentally have gradients as forces
                 all_y -= self.compute_reference_energy(z)
 
                 assert all_pos.shape[0] == all_y.shape[0]


### PR DESCRIPTION
the comp6 dataset has gradients labeled as forces by mistake