### PR TITLE
Fix inifinite recursion error on OSX

### DIFF
--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -15,31 +15,32 @@ from torchmdnet.utils import make_splits, MissingEnergyException
 from torchmdnet.models.utils import scatter
 from torchmdnet.models.utils import dtype_mapping
 
-
-class FloatCastDatasetWrapper(Dataset):
-    """A wrapper around a torch_geometric dataset that casts all floating point
-    tensors to a given dtype.
+class FloatCastDatasetWrapper:
     """
-
-    def __init__(self, dataset, dtype=torch.float64):
-        super(FloatCastDatasetWrapper, self).__init__(
-            dataset.root, dataset.transform, dataset.pre_transform, dataset.pre_filter
-        )
+    A helper class to modify the `get` method of a dataset for casting floating point tensors.
+    """
+    def __init__(self, dataset, dtype):
         self.dataset = dataset
         self.dtype = dtype
 
-    def len(self):
-        return len(self.dataset)
-
-    def get(self, idx):
+    def get_with_cast(self, idx):
+        """
+        A modified `get` method that casts floating point tensors to the specified dtype.
+        """
         data = self.dataset.get(idx)
-        for key, value in data:
+        for key, value in data.items():  # Assuming `data` is a dictionary
             if torch.is_tensor(value) and torch.is_floating_point(value):
-                setattr(data, key, value.to(self.dtype))
+                data[key] = value.to(self.dtype)
         return data
 
-    def __getattr__(self, name):
-        return getattr(self.dataset, name)
+def adapt_floats_for_dtype(dataset, dtype=torch.float64):
+    """
+    Modifies the `get` method of the given dataset to cast all floating point tensors to the specified dtype.
+    """
+    adapter = FloatCastDatasetWrapper(dataset, dtype)
+    # Replace the original get method with the new one
+    setattr(dataset, 'get', adapter.get_with_cast)
+    return dataset
 
 
 class DataModule(LightningDataModule):
@@ -82,7 +83,7 @@ class DataModule(LightningDataModule):
                     self.hparams["dataset_root"], **dataset_arg
                 )
 
-        self.dataset = FloatCastDatasetWrapper(
+        self.dataset = adapt_floats_for_dtype(
             self.dataset, dtype_mapping[self.hparams["precision"]]
         )
 

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -25,26 +25,21 @@ class FloatCastDatasetWrapper(Dataset):
         super(FloatCastDatasetWrapper, self).__init__(
             dataset.root, dataset.transform, dataset.pre_transform, dataset.pre_filter
         )
-        self.dataset = dataset
-        self.dtype = dtype
+        self._dataset = dataset
+        self._dtype = dtype
 
     def len(self):
-        return len(self.dataset)
+        return len(self._dataset)
 
     def get(self, idx):
-        data = self.dataset.get(idx)
+        data = self._dataset.get(idx)
         for key, value in data:
             if torch.is_tensor(value) and torch.is_floating_point(value):
-                setattr(data, key, value.to(self.dtype))
+                setattr(data, key, value.to(self._dtype))
         return data
 
-    def __getattr__(self, name):
-        # Check if the attribute exists in the underlying dataset
-        if hasattr(self.dataset, name):
-            return getattr(self.dataset, name)
-        raise AttributeError(
-            f"'{type(self).__name__}' and its underlying dataset have no attribute '{name}'"
-        )
+    def __getattr__(self, __name):
+        return getattr(self.__dict__["_dataset"], __name)
 
 
 class DataModule(LightningDataModule):

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -39,12 +39,7 @@ class FloatCastDatasetWrapper(Dataset):
         return data
 
     def __getattr__(self, name):
-        # Check if the attribute exists in the underlying dataset
-        if hasattr(self.dataset, name):
-            return getattr(self.dataset, name)
-        raise AttributeError(
-            f"'{type(self).__name__}' and its underlying dataset have no attribute '{name}'"
-        )
+        return getattr(self.dataset, name)
 
 
 class DataModule(LightningDataModule):

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -15,33 +15,44 @@ from torchmdnet.utils import make_splits, MissingEnergyException
 from torchmdnet.models.utils import scatter
 from torchmdnet.models.utils import dtype_mapping
 
-class FloatCastDatasetWrapper:
+class CastFloatDataset:
     """
-    A helper class to modify the `get` method of a dataset for casting floating point tensors.
+    A wrapper class for a dataset to cast all floating-point tensors to a specified dtype,
+    dynamically exposing all members of the original dataset.
     """
-    def __init__(self, dataset, dtype):
-        self.dataset = dataset
-        self.dtype = dtype
+    def __init__(self, dataset, dtype=torch.float64):
+        self._dataset = dataset  # Use a private attribute to store the original dataset
+        self._dtype = dtype
 
-    def get_with_cast(self, idx):
+    def __getitem__(self, idx):
         """
-        A modified `get` method that casts floating point tensors to the specified dtype.
+        Retrieves an item from the dataset and casts floating point tensors to the specified dtype.
         """
-        data = self.dataset.get(idx)
-        for key, value in data.items():  # Assuming `data` is a dictionary
-            if torch.is_tensor(value) and torch.is_floating_point(value):
-                data[key] = value.to(self.dtype)
+        data = self._dataset[idx]  # Directly access items from the original dataset
+        if isinstance(data, dict):  # Assuming data is a dictionary
+            for key, value in data.items():
+                if torch.is_tensor(value) and torch.is_floating_point(value):
+                    data[key] = value.to(self._dtype)
         return data
+
+    def __len__(self):
+        """
+        Returns the size of the dataset.
+        """
+        return len(self._dataset)
+
+    def __getattr__(self, name):
+        """
+        Delegates attribute access to the original dataset if the attribute is not found in the wrapper.
+        """
+        return getattr(self._dataset, name)
 
 def adapt_floats_for_dtype(dataset, dtype=torch.float64):
     """
-    Modifies the `get` method of the given dataset to cast all floating point tensors to the specified dtype.
+    Wraps the given dataset with `CastFloatDataset` to dynamically expose its interface while casting
+    floating point tensors to the specified dtype.
     """
-    adapter = FloatCastDatasetWrapper(dataset, dtype)
-    # Replace the original get method with the new one
-    setattr(dataset, 'get', adapter.get_with_cast)
-    return dataset
-
+    return CastFloatDataset(dataset, dtype)
 
 class DataModule(LightningDataModule):
     """A LightningDataModule for loading datasets from the torchmdnet.datasets module.

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -39,7 +39,12 @@ class FloatCastDatasetWrapper(Dataset):
         return data
 
     def __getattr__(self, name):
-        return getattr(self.dataset, name)
+        # Check if the attribute exists in the underlying dataset
+        if hasattr(self.dataset, name):
+            return getattr(self.dataset, name)
+        raise AttributeError(
+            f"'{type(self).__name__}' and its underlying dataset have no attribute '{name}'"
+        )
 
 
 class DataModule(LightningDataModule):


### PR DESCRIPTION
Circumvent a possible infinite recursion error in FloatCastDatasetWrapper in which getattr calls itself.
This problem only arose in OSX when a DataLoader uses more than one thread. In that case the dataset is pickled and causes an error.

This PR fixes it by making sure the getattr method in the aforementioned class does not call itself. 