### PR TITLE
Make neighbor list compatible with float16 and bfloat16

### DIFF
--- a/torchmdnet/extensions/neighbors/neighbors_cuda_brute.cuh
+++ b/torchmdnet/extensions/neighbors/neighbors_cuda_brute.cuh
@@ -100,7 +100,7 @@ forward_brute(const Tensor& positions, const Tensor& batch, const Tensor& in_box
     const uint64_t num_all_pairs = num_atoms * (num_atoms - 1UL) / 2UL;
     const uint64_t num_threads = 128;
     const uint64_t num_blocks = std::max((num_all_pairs + num_threads - 1UL) / num_threads, 1UL);
-    AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "get_neighbor_pairs_forward", [&]() {
+    DISPATCH_FOR_ALL_FLOAT_TYPES(positions.scalar_type(), "get_neighbor_pairs_forward", [&]() {
         PairListAccessor<scalar_t> list_accessor(list);
         auto box = triclinic::get_box_accessor<scalar_t>(box_vectors, use_periodic);
         const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();

--- a/torchmdnet/extensions/neighbors/neighbors_cuda_cell.cuh
+++ b/torchmdnet/extensions/neighbors/neighbors_cuda_cell.cuh
@@ -116,7 +116,7 @@ static auto sortAtomsByCellIndex(const Tensor& positions, const Tensor& box_size
     const int threads = 128;
     const int blocks = (num_atoms + threads - 1) / threads;
     auto stream = at::cuda::getCurrentCUDAStream();
-    AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "assignHash", [&] {
+    DISPATCH_FOR_ALL_FLOAT_TYPES(positions.scalar_type(), "assignHash", [&] {
         scalar_t cutoff_ = cutoff.to<scalar_t>();
         scalar3<scalar_t> box_size_ = {box_size[0][0].item<scalar_t>(),
                                        box_size[1][1].item<scalar_t>(),
@@ -229,7 +229,7 @@ CellList constructCellList(const Tensor& positions, const Tensor& batch, const T
     cl.sorted_batch = batch.index_select(0, cl.sorted_indices);
     // Step 3
     int3 cell_dim;
-    AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "computeCellDim", [&] {
+    DISPATCH_FOR_ALL_FLOAT_TYPES(positions.scalar_type(), "computeCellDim", [&] {
         scalar_t cutoff_ = cutoff.to<scalar_t>();
         scalar3<scalar_t> box_size_ = {box_size[0][0].item<scalar_t>(),
                                        box_size[1][1].item<scalar_t>(),
@@ -368,7 +368,7 @@ forward_cell(const Tensor& positions, const Tensor& batch, const Tensor& in_box_
     const auto stream = getCurrentCUDAStream(positions.get_device());
     { // Traverse the cell list to find the neighbors
         const CUDAStreamGuard guard(stream);
-        AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "forward", [&] {
+        DISPATCH_FOR_ALL_FLOAT_TYPES(positions.scalar_type(), "forward", [&] {
             const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
             TORCH_CHECK(cutoff_upper_ > 0, "Expected cutoff_upper to be positive");
             const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();

--- a/torchmdnet/extensions/neighbors/neighbors_cuda_shared.cuh
+++ b/torchmdnet/extensions/neighbors/neighbors_cuda_shared.cuh
@@ -104,7 +104,7 @@ forward_shared(const Tensor& positions, const Tensor& batch, const Tensor& in_bo
     const auto stream = getCurrentCUDAStream(positions.get_device());
     PairList list(num_pairs, positions.options(), loop, include_transpose, use_periodic);
     const CUDAStreamGuard guard(stream);
-    AT_DISPATCH_FLOATING_TYPES(positions.scalar_type(), "get_neighbor_pairs_shared_forward", [&]() {
+    DISPATCH_FOR_ALL_FLOAT_TYPES(positions.scalar_type(), "get_neighbor_pairs_shared_forward", [&]() {
         const scalar_t cutoff_upper_ = cutoff_upper.to<scalar_t>();
         const scalar_t cutoff_lower_ = cutoff_lower.to<scalar_t>();
         auto box = triclinic::get_box_accessor<scalar_t>(box_vectors, use_periodic);


### PR DESCRIPTION
This PR adds overloads for float16 and bfloat16 input/output of the neighbor extension.

Makes it possible to train in float16 or bfloat16 without casting in between.