### PR TITLE
Mark standardize as deprecated

### DIFF
--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -14,7 +14,7 @@ from torch_geometric.data import Dataset
 from torchmdnet.utils import make_splits, MissingEnergyException
 from torchmdnet.models.utils import scatter
 from torchmdnet.models.utils import dtype_mapping
-
+import warnings
 
 class FloatCastDatasetWrapper(Dataset):
     """A wrapper around a torch_geometric dataset that casts all floating point
@@ -104,6 +104,11 @@ class DataModule(LightningDataModule):
         self.test_dataset = Subset(self.dataset, self.idx_test)
 
         if self.hparams["standardize"]:
+            # Mark as deprecated
+            warnings.warn(
+                "The standardize option is deprecated and will be removed in the future. ",
+                DeprecationWarning,
+            )
             self._standardize()
 
     def train_dataloader(self):


### PR DESCRIPTION
Following #277 and some internal discussion we are moving away from Dataset standardisation.
We believe its current implementation is not the best fit for NNPs but for the moment we are leaving the option there for backwards compatibility. It will be removed at some point.

We could instead simply remove the feature altogether or make it more sensible, like offering alternative approaches as to how the mean is computed.

This is your last chance if you have an opinion about this!
Closes #277