### PR TITLE
Training with relative energies, infering with total energy.

### DIFF
--- a/docs/source/datasets.rst
+++ b/docs/source/datasets.rst
@@ -64,12 +64,41 @@ If you want to train on custom data, first have a look at :py:mod:`torchmdnet.da
 
 To add a new dataset, you need to:
 
-1. Write a new class inheriting from :py:mod:`torch_geometric.data.Dataset`, see `here <https://pytorch-geometric.readthedocs.io/en/latest/tutorial/create_dataset.html>`_ for a tutorial on that.
+1. Write a new class inheriting from :py:mod:`torch_geometric.data.Dataset`, see `here <https://pytorch-geometric.readthedocs.io/en/latest/tutorial/create_dataset.html>`_ for a tutorial on that. You may also start from :ref:`one of the base datasets we provide <base datasets>`.
 2. Add the new class to the :py:mod:`torchmdnet.datasets` module (by listing it in the `__all__` variable in the `datasets/__init__.py` file) so that the :ref:`configuration file <configuration-file>` recognizes it.
 
 .. note::
 
    The dataset must return torch-geometric `Data` objects, containing at least the keys `z` (atom types) and `pos` (atomic coordinates), as well as `y` (label), `neg_dy` (negative derivative of the label w.r.t atom coordinates) or both.
+
+
+Datasets and Atomref
+--------------------
+
+Compatibility with the :py:mod:`torchmdnet.priors.Atomref` prior (and thus :ref:`delta learning <delta-learning>`) requires the dataset to define a method called :code:`get_atomref` as follows:
+
+.. code:: python
+
+   class MyDataset(Dataset):
+       # ...
+       def get_atomref(self, max_z=100):
+          """Atomic energy reference values.
+	  Args:
+	      max_z (int): Maximum atomic number
+	  Returns:
+	      torch.Tensor: Atomic energy reference values for each element in the dataset.
+	  """
+          refs = pt.zeros(max_z)
+	  # Set the references for each element present in the dataset.
+	  refs[1] = -0.500607632585
+	  refs[6] = -37.8302333826
+	  refs[7] = -54.5680045287
+	  refs[8] = -75.0362229210
+	  # ...
+          return refs.view(-1, 1)
+
+
+
 
 Available Datasets
 ------------------
@@ -79,3 +108,17 @@ Available Datasets
       
    .. include:: generated/torchmdnet.datasets.rst
       :start-line: 5
+
+.. _base datasets:
+Base Datasets
+-------------
+The following datasets are used as a base for other datasets.
+
+.. autoclass:: torchmdnet.datasets.ani.ANIBase
+   :noindex:
+
+.. autoclass:: torchmdnet.datasets.comp6.COMP6Base
+   :noindex:
+
+.. autoclass:: torchmdnet.datasets.memdataset.MemmappedDataset
+   :noindex:

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -42,26 +42,43 @@ Training on relative energies
 -----------------------------
 
 It might be useful to train the model on relative energies but then make the model produce total energies when running inference.
-TorchMD-Net supports this via a combination of a Dataset option and the :py:mod:`torchmdnet.priors.Atomref` prior. To enable this behavior you must:
+TorchMD-Net supports delta training via the :code:`remove_ref_energy` option. Passing this option when training (either via the :ref:`configuration-file` or using the :ref:`torchmd-train` command line interface) will subtract the reference energy from each atom in a sample before passing it to the model.
 
-When training:
-1. Set :code:`remove_ref_energy=True` as an argument to the :ref:`Dataset <Datasets>`.
-2. Add the :py:mod:`torchmdnet.priors.Atomref` prior passing it the :code:`enable=False` option.
+.. note:: Delta learning requires a :ref:`dataset <Datasets>` that is compatible with :py:mod:`torchmdnet.priors.Atomref`.
 
-.. note:: Adding the Atomref prior makes it so that the reference energies are stored in the model checkpoint as a buffer.
-   
-When loading for inference:
-1. Set the :py:mod:`torchmdnet.priors.Atomref` prior to :code:`enable=True`.
+If :code:`remove_ref_energy` is turned on, the reference energy is stored in the checkpoint file and is added back to the output of the model during inference if the model is loaded with :code:`remove_ref_energy=False`.
 
-.. hint:: This can be achieved by setting the prior_model as enabled after its creation:
-	  
-	  .. code:: python
-		    
-		    model = load_model(checkpoint)
-		    [prior.enable=True for prior in model.prior_model if isinstance(prior, torchmdnet.priors.Atomref)]
+.. note:: The reference energies are stored as an :py:mod:`torchmdnet.priors.Atomref` prior with :code:`enable=False`.
 
-		    
-		    
+Example
+~~~~~~~
+
+First we train a model with the :code:`remove_ref_energy` option turned on:
+
+.. code:: shell
+
+	  torchmd-train --config /path/to/config.yaml --remove_ref_energy
+
+Then we load the model for inference:
+
+.. code:: python
+
+	  import torch
+	  from torchmdnet.models.model import load_model
+	  checkpoint = "/path/to/checkpoint/my_checkpoint.ckpt"  
+	  model = load_model(checkpoint, remove_ref_energy=False)
+
+	  # An arbitrary set of inputs for the model
+	  n_atoms = 10   
+	  zs = torch.tensor([1, 6, 7, 8, 9], dtype=torch.long)
+	  z = zs[torch.randint(0, len(zs), (n_atoms,))]
+	  pos = torch.randn(len(z), 3)
+	  batch = torch.zeros(len(z), dtype=torch.long)
+
+	  y, neg_dy = model(z, pos, batch)
+
+
+
 Integration with MD packages
 -----------------------------
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -37,7 +37,7 @@ Once you have trained a model you should have a checkpoint that you can load for
 
 .. note:: When periodic boundary conditions are required, modules typically offer the possibility of providing the box vectors at construction and/or as an argument to the forward pass. Check the documentation of the class you are using to see if this is the case.
 
-
+.. _delta-learning:
 Training on relative energies
 -----------------------------
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -51,14 +51,15 @@ When training:
 .. note:: Adding the Atomref prior makes it so that the reference energies are stored in the model checkpoint as a buffer.
    
 When loading for inference:
-1. Set the :py:mod:`torchmdnet.priors.Atomref` prior to enable.
+1. Set the :py:mod:`torchmdnet.priors.Atomref` prior to :code:`enable=True`.
 
 .. hint:: This can be achieved by setting the prior_model as enabled after its creation:
 	  
 	  .. code:: python
 		    
 		    model = load_model(checkpoint)
-		    model.prior_model[0].enable = True
+		    [prior.enable=True for prior in model.prior_model if isinstance(prior, torchmdnet.priors.Atomref)]
+
 		    
 		    
 Integration with MD packages

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -38,8 +38,29 @@ Once you have trained a model you should have a checkpoint that you can load for
 .. note:: When periodic boundary conditions are required, modules typically offer the possibility of providing the box vectors at construction and/or as an argument to the forward pass. Check the documentation of the class you are using to see if this is the case.
 
 
+Training on relative energies
+-----------------------------
 
+It might be useful to train the model on relative energies but then make produce total energies when running inference.
+TorchMD-Net supports this via a combination of a Dataset option and the :py:mod:`torchmdnet.priors.Atomref` prior. To enable this behavior you must:
 
+When training:
+1. Set :code:`remove_ref_energy=True` as an argument to the :ref:`Dataset <Datasets>`.
+2. Add the :py:mod:`torchmdnet.priors.Atomref` prior passing it the :code:`enable=False` option.
+
+.. note:: Adding the Atomref prior makes it so that the reference energies are stored in the model checkpoint as a buffer.
+   
+When loading for inference:
+1. Set the :py:mod:`torchmdnet.priors.Atomref` prior to enable.
+
+.. hint:: This can be achieved by setting the prior_model as enabled after its creation:
+	  
+	  .. code:: python
+		    
+		    model = load_model(checkpoint)
+		    model.prior_model[0].enable = True
+		    
+		    
 Integration with MD packages
 -----------------------------
 

--- a/docs/source/models.rst
+++ b/docs/source/models.rst
@@ -41,7 +41,7 @@ Once you have trained a model you should have a checkpoint that you can load for
 Training on relative energies
 -----------------------------
 
-It might be useful to train the model on relative energies but then make produce total energies when running inference.
+It might be useful to train the model on relative energies but then make the model produce total energies when running inference.
 TorchMD-Net supports this via a combination of a Dataset option and the :py:mod:`torchmdnet.priors.Atomref` prior. To enable this behavior you must:
 
 When training:

--- a/tests/test_datamodule.py
+++ b/tests/test_datamodule.py
@@ -28,6 +28,27 @@ def test_datamodule_create(tmpdir):
     dl2 = data._get_dataloader(data.train_dataset, "train", store_dataloader=False)
     assert dl1 is not dl2
 
+def test_dataloader_get(tmpdir):
+    args = load_example_args("graph-network")
+    args["train_size"] = 800
+    args["val_size"] = 100
+    args["test_size"] = 100
+    args["log_dir"] = tmpdir
+
+    dataset = DummyDataset()
+    data = DataModule(args, dataset=dataset)
+    data.prepare_data()
+    data.setup("fit")
+    # Get the first element of the training set
+    assert data.train_dataloader().dataset[0] is not None
+    # Assert the elements are in there (z, pos, y, neg_dy)
+    item = data.train_dataloader().dataset[0]
+    assert "z" in item
+    assert "pos" in item
+    assert "y" in item
+    assert "neg_dy" in item
+    # Assert that the dataloader is not empty
+    assert len(data.train_dataloader()) > 0
 
 @mark.parametrize("energy,forces", [(True, True), (True, False), (False, True)])
 @mark.parametrize("has_atomref", [True, False])

--- a/tests/test_dataset_comp6.py
+++ b/tests/test_dataset_comp6.py
@@ -39,7 +39,7 @@ def test_dataset_s66x8():
             ),
             atol=1e-4,
         )
-        assert pt.allclose(sample.y, pt.tensor([[-47.5919]]))
+        assert pt.allclose(sample.y, pt.tensor([[-5755.7288331]],dtype=pt.float64))
         assert pt.allclose(
             sample.neg_dy,
             -pt.tensor(

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -56,28 +56,3 @@ def test_train(model_name, use_atomref, precision, tmpdir):
     trainer = pl.Trainer(max_steps=10, default_root_dir=tmpdir, precision=args["precision"],inference_mode=False)
     trainer.fit(module, datamodule)
     trainer.test(module, datamodule)
-
-
-def test_remove_ref_energy(tmpdir):
-    args = load_example_args(
-        "tensornet",
-        remove_prior=True,
-        train_size=0.8,
-        val_size=0.05,
-        test_size=None,
-        log_dir=tmpdir,
-        derivative=True,
-        embedding_dimension=16,
-        num_layers=2,
-        num_rbf=16,
-        batch_size=8,
-        precision=32,
-        remove_ref_energy=True,
-    )
-
-    datamodule = DataModule(args, DummyDataset(has_atomref=True))
-    module = LNNP(args, atomref=datamodule.atomref)
-
-    trainer = pl.Trainer(max_steps=10, default_root_dir=tmpdir, precision=args["precision"],inference_mode=False)
-    trainer.fit(module, datamodule)
-    trainer.test(module, datamodule)

--- a/tests/test_module.py
+++ b/tests/test_module.py
@@ -56,3 +56,28 @@ def test_train(model_name, use_atomref, precision, tmpdir):
     trainer = pl.Trainer(max_steps=10, default_root_dir=tmpdir, precision=args["precision"],inference_mode=False)
     trainer.fit(module, datamodule)
     trainer.test(module, datamodule)
+
+
+def test_remove_ref_energy(tmpdir):
+    args = load_example_args(
+        "tensornet",
+        remove_prior=True,
+        train_size=0.8,
+        val_size=0.05,
+        test_size=None,
+        log_dir=tmpdir,
+        derivative=True,
+        embedding_dimension=16,
+        num_layers=2,
+        num_rbf=16,
+        batch_size=8,
+        precision=32,
+        remove_ref_energy=True,
+    )
+
+    datamodule = DataModule(args, DummyDataset(has_atomref=True))
+    module = LNNP(args, atomref=datamodule.atomref)
+
+    trainer = pl.Trainer(max_steps=10, default_root_dir=tmpdir, precision=args["precision"],inference_mode=False)
+    trainer.fit(module, datamodule)
+    trainer.test(module, datamodule)

--- a/tests/test_priors.py
+++ b/tests/test_priors.py
@@ -43,6 +43,12 @@ def test_atomref(model_name, enable_atomref):
         expected_offset = 0
     torch.testing.assert_allclose(x_atomref, x_no_atomref + expected_offset)
 
+@mark.parametrize("trainable", [True, False])
+def test_atomref_trainable(trainable):
+    dataset = DummyDataset(has_atomref=True)
+    atomref = Atomref(max_z=100, dataset=dataset, trainable=trainable)
+    assert atomref.atomref.weight.requires_grad == trainable
+
 def test_zbl():
     pos = torch.tensor([[1.0, 0.0, 0.0], [2.5, 0.0, 0.0], [1.0, 1.0, 0.0], [0.0, 0.0, -1.0]], dtype=torch.float32)  # Atom positions in Bohr
     types = torch.tensor([0, 1, 2, 1], dtype=torch.long)  # Atom types

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -24,6 +24,8 @@ def load_example_args(model_name, remove_prior=False, config_file=None, **kwargs
         args["prior_model"] = None
     if "box_vecs" not in args:
         args["box_vecs"] = None
+    if "remove_ref_energy" not in args:
+        args["remove_ref_energy"] = False
     for key, val in kwargs.items():
         assert key in args, f"Broken test! Unknown key '{key}'."
         args[key] = val

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -13,33 +13,6 @@ from torchmdnet import datasets
 from torch_geometric.data import Dataset
 from torchmdnet.utils import make_splits, MissingEnergyException
 from torchmdnet.models.utils import scatter
-from torchmdnet.models.utils import dtype_mapping
-
-
-class FloatCastDatasetWrapper(Dataset):
-    """A wrapper around a torch_geometric dataset that casts all floating point
-    tensors to a given dtype.
-    """
-
-    def __init__(self, dataset, dtype=torch.float64):
-        super(FloatCastDatasetWrapper, self).__init__(
-            dataset.root, dataset.transform, dataset.pre_transform, dataset.pre_filter
-        )
-        self._dataset = dataset
-        self._dtype = dtype
-
-    def len(self):
-        return len(self._dataset)
-
-    def get(self, idx):
-        data = self._dataset.get(idx)
-        for key, value in data:
-            if torch.is_tensor(value) and torch.is_floating_point(value):
-                setattr(data, key, value.to(self._dtype))
-        return data
-
-    def __getattr__(self, __name):
-        return getattr(self.__getattribute__("_dataset"), __name)
 
 
 class DataModule(LightningDataModule):
@@ -81,10 +54,6 @@ class DataModule(LightningDataModule):
                 self.dataset = getattr(datasets, self.hparams["dataset"])(
                     self.hparams["dataset_root"], **dataset_arg
                 )
-
-        self.dataset = FloatCastDatasetWrapper(
-            self.dataset, dtype_mapping[self.hparams["precision"]]
-        )
 
         self.idx_train, self.idx_val, self.idx_test = make_splits(
             len(self.dataset),

--- a/torchmdnet/datasets/ani.py
+++ b/torchmdnet/datasets/ani.py
@@ -46,7 +46,14 @@ class ANIBase(MemmappedDataset):
         raise NotImplementedError
 
     def get_atomref(self, max_z=100):
-        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior."""
+        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior.
+
+	  Args:
+	      max_z (int): Maximum atomic number
+
+	  Returns:
+	      torch.Tensor: Atomic energy reference values for each element in the dataset.
+	"""
         refs = pt.zeros(max_z)
         for key, val in self._ELEMENT_ENERGIES.items():
             refs[key] = val * self.HARTREE_TO_EV

--- a/torchmdnet/datasets/ani.py
+++ b/torchmdnet/datasets/ani.py
@@ -45,11 +45,6 @@ class ANIBase(MemmappedDataset):
     def raw_file_names(self):
         raise NotImplementedError
 
-    def compute_reference_energy(self, atomic_numbers):
-        atomic_numbers = np.array(atomic_numbers)
-        energy = sum(self._ELEMENT_ENERGIES[z] for z in atomic_numbers)
-        return energy * ANIBase.HARTREE_TO_EV
-
     def get_atomref(self, max_z=100):
         raise NotImplementedError()
 

--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -60,7 +60,14 @@ class COMP6Base(MemmappedDataset):
         ]
 
     def get_atomref(self, max_z=100):
-        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior."""
+        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior.
+
+	  Args:
+	      max_z (int): Maximum atomic number
+
+	  Returns:
+	      torch.Tensor: Atomic energy reference values for each element in the dataset.
+	"""
         refs = pt.zeros(max_z)
         for key, val in self._ELEMENT_ENERGIES.items():
             refs[key] = val * self.HARTREE_TO_EV
@@ -338,7 +345,14 @@ class COMP6v2(ANIBase):
                         yield data
 
     def get_atomref(self, max_z=100):
-        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior."""
+        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior.
+
+	  Args:
+	      max_z (int): Maximum atomic number
+
+	  Returns:
+	      torch.Tensor: Atomic energy reference values for each element in the dataset.
+	"""
         refs = pt.zeros(max_z)
         for key, val in self._ELEMENT_ENERGIES.items():
             refs[key] = val * self.HARTREE_TO_EV

--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -23,7 +23,7 @@ For more details check:
 
 
 class COMP6Base(MemmappedDataset):
-    ELEMENT_ENERGIES = {
+    _ELEMENT_ENERGIES = {
         1: -0.500607632585,
         6: -37.8302333826,
         7: -54.5680045287,
@@ -45,7 +45,6 @@ class COMP6Base(MemmappedDataset):
             transform,
             pre_transform,
             pre_filter,
-            remove_ref_energy=False,
             properties=("y", "neg_dy"),
         )
 
@@ -60,11 +59,13 @@ class COMP6Base(MemmappedDataset):
             f"{url_prefix}/{self.raw_url_name}/{name}" for name in self.raw_file_names
         ]
 
-    @staticmethod
-    def compute_reference_energy(atomic_numbers):
-        atomic_numbers = np.array(atomic_numbers)
-        energy = sum(COMP6Base.ELEMENT_ENERGIES[z] for z in atomic_numbers)
-        return energy * COMP6Base.HARTREE_TO_EV
+    def get_atomref(self, max_z=100):
+        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior."""
+        refs = pt.zeros(max_z)
+        for key, val in self._ELEMENT_ENERGIES.items():
+            refs[key] = val * self.HARTREE_TO_EV
+
+        return refs.view(-1, 1)
 
     def download(self):
         for url in self.raw_url:

--- a/torchmdnet/datasets/comp6.py
+++ b/torchmdnet/datasets/comp6.py
@@ -90,7 +90,6 @@ class COMP6Base(MemmappedDataset):
                 all_neg_dy = (
                     -all_neg_dy
                 )  # The COMP6 datasets accidentally have gradients as forces
-                all_y -= self.compute_reference_energy(z)
 
                 assert all_pos.shape[0] == all_y.shape[0]
                 assert all_pos.shape[1] == z.shape[0]

--- a/torchmdnet/datasets/custom.py
+++ b/torchmdnet/datasets/custom.py
@@ -24,16 +24,9 @@ class Custom(Dataset):
         forceglob (string, optional): Glob path for force files. Stored as "neg_dy".
             (default: :obj:`None`)
         preload_memory_limit (int, optional): If the dataset is smaller than this limit (in MB), preload it into CPU memory.
-        transform (callable, optional): A function/transform that takes in an
-        :obj:`torch_geometric.data.Data` object and returns a transformed
-        version. The data object will be transformed before every access.
-    pre_transform (callable, optional): A function/transform that takes in an
-        :obj:`torch_geometric.data.Data` object and returns a transformed
-        version. The data object will be transformed before being saved to disk.
-    pre_filter (callable, optional): A function that takes in an
-        :obj:`torch_geometric.data.Data` object and returns a boolean value,
-        indicating whether the data object should be included in the final
-        dataset.
+        transform (callable, optional): A function/transform that takes in an :obj:`torch_geometric.data.Data` object and returns a transformed version. The data object will be transformed before every access.
+        pre_transform (callable, optional): A function/transform that takes in an :obj:`torch_geometric.data.Data` object and returns a transformed version. The data object will be transformed before being saved to disk.
+        pre_filter (callable, optional): A function that takes in an :obj:`torch_geometric.data.Data` object and returns a boolean value, indicating whether the data object should be included in the final dataset.
 
 
     Example:

--- a/torchmdnet/datasets/memdataset.py
+++ b/torchmdnet/datasets/memdataset.py
@@ -33,20 +33,20 @@ class MemmappedDataset(Dataset):
         - :obj:`name.dp.mmap`: Dipole moment of each conformation.
 
     Args:
-    root (str): Root directory where the dataset should be stored.
-    transform (callable, optional): A function/transform that takes in an
-        :obj:`torch_geometric.data.Data` object and returns a transformed
-        version. The data object will be transformed before every access.
-    pre_transform (callable, optional): A function/transform that takes in an
-        :obj:`torch_geometric.data.Data` object and returns a transformed
-        version. The data object will be transformed before being saved to disk.
-    pre_filter (callable, optional): A function that takes in an
-        :obj:`torch_geometric.data.Data` object and returns a boolean value,
-        indicating whether the data object should be included in the final
-        dataset.
-    properties (tuple of str, optional): The properties to include in the
-        dataset. Can be any subset of :obj:`y`, :obj:`neg_dy`, :obj:`q`,
-        :obj:`pq`, and :obj:`dp`.
+        root (str): Root directory where the dataset should be stored.
+        transform (callable, optional): A function/transform that takes in an
+            :obj:`torch_geometric.data.Data` object and returns a transformed
+            version. The data object will be transformed before every access.
+        pre_transform (callable, optional): A function/transform that takes in an
+            :obj:`torch_geometric.data.Data` object and returns a transformed
+            version. The data object will be transformed before being saved to disk.
+        pre_filter (callable, optional): A function that takes in an
+            :obj:`torch_geometric.data.Data` object and returns a boolean value,
+            indicating whether the data object should be included in the final
+            dataset.
+        properties (tuple of str, optional): The properties to include in the
+            dataset. Can be any subset of :obj:`y`, :obj:`neg_dy`, :obj:`q`,
+            :obj:`pq`, and :obj:`dp`.
     """
 
     def __init__(

--- a/torchmdnet/datasets/memdataset.py
+++ b/torchmdnet/datasets/memdataset.py
@@ -32,6 +32,21 @@ class MemmappedDataset(Dataset):
         - :obj:`name.pq.mmap`: Partial charges of all the atoms.
         - :obj:`name.dp.mmap`: Dipole moment of each conformation.
 
+    Args:
+    root (str): Root directory where the dataset should be stored.
+    transform (callable, optional): A function/transform that takes in an
+        :obj:`torch_geometric.data.Data` object and returns a transformed
+        version. The data object will be transformed before every access.
+    pre_transform (callable, optional): A function/transform that takes in an
+        :obj:`torch_geometric.data.Data` object and returns a transformed
+        version. The data object will be transformed before being saved to disk.
+    pre_filter (callable, optional): A function that takes in an
+        :obj:`torch_geometric.data.Data` object and returns a boolean value,
+        indicating whether the data object should be included in the final
+        dataset.
+    properties (tuple of str, optional): The properties to include in the
+        dataset. Can be any subset of :obj:`y`, :obj:`neg_dy`, :obj:`q`,
+        :obj:`pq`, and :obj:`dp`.
     """
 
     def __init__(
@@ -40,11 +55,9 @@ class MemmappedDataset(Dataset):
         transform=None,
         pre_transform=None,
         pre_filter=None,
-        remove_ref_energy=False,
         properties=("y", "neg_dy", "q", "pq", "dp"),
     ):
         self.name = self.__class__.__name__
-        self.remove_ref_energy = remove_ref_energy
         self.properties = properties
         super().__init__(root, transform, pre_transform, pre_filter)
 
@@ -91,10 +104,6 @@ class MemmappedDataset(Dataset):
                 ["idx", "z", "pos"] + list(self.properties), self.processed_paths
             )
         }
-
-    @staticmethod
-    def compute_reference_energy(self):
-        raise NotImplementedError
 
     def sample_iter(self, mol_ids=False):
         raise NotImplementedError()
@@ -236,20 +245,17 @@ class MemmappedDataset(Dataset):
         """
         atoms = slice(self.idx_mm[idx], self.idx_mm[idx + 1])
         z = pt.tensor(self.z_mm[atoms], dtype=pt.long)
-        pos = pt.tensor(self.pos_mm[atoms], dtype=pt.float32)
+        pos = pt.tensor(self.pos_mm[atoms])
 
         props = {}
         if "y" in self.properties:
-            y = self.y_mm[idx]
-            if self.remove_ref_energy:
-                y -= self.compute_reference_energy(z)
-            props["y"] = pt.tensor(y, dtype=pt.float32).view(1, 1)
+            props["y"] = pt.tensor(self.y_mm[idx]).view(1, 1)
         if "neg_dy" in self.properties:
-            props["neg_dy"] = pt.tensor(self.neg_dy_mm[atoms], dtype=pt.float32)
+            props["neg_dy"] = pt.tensor(self.neg_dy_mm[atoms])
         if "q" in self.properties:
             props["q"] = pt.tensor(self.q_mm[idx], dtype=pt.long)
         if "pq" in self.properties:
-            props["pq"] = pt.tensor(self.pq_mm[atoms], dtype=pt.float32)
+            props["pq"] = pt.tensor(self.pq_mm[atoms])
         if "dp" in self.properties:
-            props["dp"] = pt.tensor(self.dp_mm[idx], dtype=pt.float32)
+            props["dp"] = pt.tensor(self.dp_mm[idx])
         return Data(z=z, pos=pos, **props)

--- a/torchmdnet/datasets/qm9.py
+++ b/torchmdnet/datasets/qm9.py
@@ -28,6 +28,14 @@ class QM9(QM9_geometric):
         super(QM9, self).__init__(root, transform=transform)
 
     def get_atomref(self, max_z=100):
+        """Atomic energy reference values for the :py:mod:`torchmdnet.priors.Atomref` prior.
+
+	  Args:
+	      max_z (int): Maximum atomic number
+
+	  Returns:
+	      torch.Tensor: Atomic energy reference values for each element in the dataset.
+	"""
         atomref = self.atomref(self.label_idx)
         if atomref is None:
             return None

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -165,6 +165,7 @@ def load_model(filepath, args=None, device="cpu", **kwargs):
     if delta_learning and "remove_ref_energy" in kwargs:
         if not kwargs["remove_ref_energy"]:
             assert len(model.prior_model) > 0, "Atomref prior must be added during training (with enable=False) for total energy prediction."
+            assert isinstance(model.prior_model[-1], priors.Atomref), "I expected the last prior to be Atomref."
             # Set the Atomref prior to enabled
             model.prior_model[-1].enable = True
 

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -162,28 +162,6 @@ def load_model(filepath, args=None, device="cpu", **kwargs):
     model = create_model(args)
 
     state_dict = {re.sub(r"^model\.", "", k): v for k, v in ckpt["state_dict"].items()}
-    # The following are for backward compatibility with models created when atomref was
-    # the only supported prior.
-    if "prior_model.initial_atomref" in state_dict:
-        warnings.warn(
-            "prior_model.initial_atomref is deprecated and will be removed in a future version. Use prior_model.0.initial_atomref instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        state_dict["prior_model.0.initial_atomref"] = state_dict[
-            "prior_model.initial_atomref"
-        ]
-        del state_dict["prior_model.initial_atomref"]
-    if "prior_model.atomref.weight" in state_dict:
-        warnings.warn(
-            "prior_model.atomref.weight is deprecated and will be removed in a future version. Use prior_model.0.atomref.weight instead.",
-            category=DeprecationWarning,
-            stacklevel=2,
-        )
-        state_dict["prior_model.0.atomref.weight"] = state_dict[
-            "prior_model.atomref.weight"
-        ]
-        del state_dict["prior_model.atomref.weight"]
     model.load_state_dict(state_dict)
     return model.to(device)
 

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -167,7 +167,44 @@ def load_model(filepath, args=None, device="cpu", **kwargs):
 
 
 def create_prior_models(args, dataset=None):
-    """Parse the prior_model configuration option and create the prior models."""
+    """Parse the prior_model configuration option and create the prior models.
+
+    The information can be passed in different ways via the args dictionary, which must contain at least the key "prior_model".
+
+    1. A single prior model name and its arguments as a dictionary:
+
+    ```python
+    args = {
+        "prior_model": "Atomref",
+        "prior_args": {"max_z": 100}
+    }
+    ```
+    2. A list of prior model names and their arguments as a list of dictionaries:
+
+    ```python
+
+    args = {
+        "prior_model": ["Atomref", "D2"],
+        "prior_args": [{"max_z": 100}, {"max_z": 100}]
+    }
+    ```
+
+    3. A list of prior model names and their arguments as a dictionary:
+
+    ```python
+    args = {
+        "prior_model": [{"Atomref": {"max_z": 100}}, {"D2": {"max_z": 100}}]
+    }
+    ```
+
+    Args:
+        args (dict): Arguments for the model.
+        dataset (torch_geometric.data.Dataset, optional): A dataset from which to extract the atomref values. Defaults to None.
+
+    Returns:
+        list: A list of prior models.
+
+    """
     prior_models = []
     if args["prior_model"]:
         prior_model = args["prior_model"]

--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -16,7 +16,7 @@ from torchmdnet.models.utils import dtype_mapping
 import torch_geometric.transforms as T
 
 class FloatCastDatasetWrapper(T.BaseTransform):
-    """A wrapper around a torch_geometric dataset that casts all floating point
+    """A transform that casts all floating point tensors to a given dtype.
     tensors to a given dtype.
     """
 
@@ -32,6 +32,9 @@ class FloatCastDatasetWrapper(T.BaseTransform):
 
 
 class EnergyRefRemover(T.BaseTransform):
+    """A transform that removes the atom reference energy from the energy of a
+    dataset.
+    """
 
     def __init__(self, atomref):
         super(EnergyRefRemover, self).__init__()

--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -54,10 +54,9 @@ class LNNP(LightningModule):
         prior_model (torchmdnet.priors.BasePrior): A prior model to use in the model.
         mean (torch.Tensor, optional): The mean of the dataset to normalize the input.
         std (torch.Tensor, optional): The standard deviation of the dataset to normalize the input.
-        atomref (torch.Tensor): A tensor containing the atom reference energies for each atom type.
     """
 
-    def __init__(self, hparams, prior_model=None, mean=None, std=None, atomref=None):
+    def __init__(self, hparams, prior_model=None, mean=None, std=None):
         super(LNNP, self).__init__()
         if "charge" not in hparams:
             hparams["charge"] = False
@@ -81,9 +80,8 @@ class LNNP(LightningModule):
 
         self.data_transform = FloatCastDatasetWrapper(dtype_mapping[self.hparams.precision])
         if self.hparams.remove_ref_energy:
-            assert atomref is not None, "Atomref must be provided if remove_ref_energy is True"
             self.data_transform = T.Compose(
-                [EnergyRefRemover(atomref), self.data_transform]
+                [EnergyRefRemover(self.model.prior_model[-1].initial_atomref), self.data_transform]
             )
 
     def configure_optimizers(self):

--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -12,14 +12,49 @@ from typing import Optional, Dict, Tuple
 
 from lightning import LightningModule
 from torchmdnet.models.model import create_model, load_model
+from torchmdnet.models.utils import dtype_mapping
+import torch_geometric.transforms as T
 
+class FloatCastDatasetWrapper(T.BaseTransform):
+    """A wrapper around a torch_geometric dataset that casts all floating point
+    tensors to a given dtype.
+    """
+
+    def __init__(self, dtype=torch.float64):
+        super(FloatCastDatasetWrapper, self).__init__()
+        self._dtype = dtype
+
+    def forward(self, data):
+        for key, value in data:
+            if torch.is_tensor(value) and torch.is_floating_point(value):
+                setattr(data, key, value.to(self._dtype))
+        return data
+
+
+class EnergyRefRemover(T.BaseTransform):
+
+    def __init__(self, atomref):
+        super(EnergyRefRemover, self).__init__()
+        self._atomref = atomref
+
+    def forward(self, data):
+        if "y" in data:
+            data.y -= self._atomref[data.z].sum()
+        return data
 
 class LNNP(LightningModule):
     """
     Lightning wrapper for the Neural Network Potentials in TorchMD-Net.
+
+    Args:
+        hparams (dict): A dictionary containing the hyperparameters of the model.
+        prior_model (torchmdnet.priors.BasePrior): A prior model to use in the model.
+        mean (torch.Tensor, optional): The mean of the dataset to normalize the input.
+        std (torch.Tensor, optional): The standard deviation of the dataset to normalize the input.
+        atomref (torch.Tensor): A tensor containing the atom reference energies for each atom type.
     """
 
-    def __init__(self, hparams, prior_model=None, mean=None, std=None):
+    def __init__(self, hparams, prior_model=None, mean=None, std=None, atomref=None):
         super(LNNP, self).__init__()
         if "charge" not in hparams:
             hparams["charge"] = False
@@ -40,6 +75,13 @@ class LNNP(LightningModule):
         # initialize loss collection
         self.losses = None
         self._reset_losses_dict()
+
+        self.data_transform = FloatCastDatasetWrapper(dtype_mapping[self.hparams.precision])
+        if self.hparams.remove_ref_energy:
+            assert atomref is not None, "Atomref must be provided if remove_ref_energy is True"
+            self.data_transform = T.Compose(
+                [EnergyRefRemover(atomref), self.data_transform]
+            )
 
     def configure_optimizers(self):
         optimizer = AdamW(
@@ -145,6 +187,7 @@ class LNNP(LightningModule):
         #   total_loss: sum of all losses (weighted by the loss weights) for the last loss function in the provided list
         assert len(loss_fn_list) > 0
         assert self.losses is not None
+        batch = self.data_transform(batch)
         with torch.set_grad_enabled(stage == "train" or self.hparams.derivative):
             extra_args = batch.to_dict()
             for a in ("y", "neg_dy", "z", "pos", "batch", "box", "q", "s"):

--- a/torchmdnet/priors/atomref.py
+++ b/torchmdnet/priors/atomref.py
@@ -47,8 +47,7 @@ class Atomref(BasePrior):
         if atomref.ndim == 1:
             atomref = atomref.view(-1, 1)
         self.register_buffer("initial_atomref", atomref)
-        self.atomref = nn.Embedding(len(atomref), 1, _freeze=not trainable)
-        self.atomref.weight.data.copy_(atomref)
+        self.atomref = nn.Embedding(len(atomref), 1, _freeze=not trainable, _weight=atomref)
         self.enable = enable
 
     def reset_parameters(self):

--- a/torchmdnet/priors/atomref.py
+++ b/torchmdnet/priors/atomref.py
@@ -54,7 +54,7 @@ class Atomref(BasePrior):
         self.atomref.weight.data.copy_(self.initial_atomref)
 
     def get_init_args(self):
-        return dict(max_z=self.initial_atomref.size(0))
+        return dict(max_z=self.initial_atomref.size(0), trainable=self.atomref.weight.requires_grad, enable=self.enable)
 
     def pre_reduce(
         self,

--- a/torchmdnet/priors/atomref.py
+++ b/torchmdnet/priors/atomref.py
@@ -47,7 +47,7 @@ class Atomref(BasePrior):
         if atomref.ndim == 1:
             atomref = atomref.view(-1, 1)
         self.register_buffer("initial_atomref", atomref)
-        self.atomref = nn.Embedding(len(atomref), 1, _freeze=trainable and not enable)
+        self.atomref = nn.Embedding(len(atomref), 1, _freeze=not trainable)
         self.atomref.weight.data.copy_(atomref)
         self.enable = enable
 

--- a/torchmdnet/priors/atomref.py
+++ b/torchmdnet/priors/atomref.py
@@ -47,7 +47,7 @@ class Atomref(BasePrior):
         if atomref.ndim == 1:
             atomref = atomref.view(-1, 1)
         self.register_buffer("initial_atomref", atomref)
-        self.atomref = nn.Embedding(len(atomref), 1, freeze=trainable and not enable)
+        self.atomref = nn.Embedding(len(atomref), 1, _freeze=trainable and not enable)
         self.atomref.weight.data.copy_(atomref)
         self.enable = enable
 

--- a/torchmdnet/priors/atomref.py
+++ b/torchmdnet/priors/atomref.py
@@ -47,14 +47,20 @@ class Atomref(BasePrior):
         if atomref.ndim == 1:
             atomref = atomref.view(-1, 1)
         self.register_buffer("initial_atomref", atomref)
-        self.atomref = nn.Embedding(len(atomref), 1, _freeze=not trainable, _weight=atomref)
+        self.atomref = nn.Embedding(
+            len(atomref), 1, _freeze=not trainable, _weight=atomref
+        )
         self.enable = enable
 
     def reset_parameters(self):
         self.atomref.weight.data.copy_(self.initial_atomref)
 
     def get_init_args(self):
-        return dict(max_z=self.initial_atomref.size(0), trainable=self.atomref.weight.requires_grad, enable=self.enable)
+        return dict(
+            max_z=self.initial_atomref.size(0),
+            trainable=self.atomref.weight.requires_grad,
+            enable=self.enable,
+        )
 
     def pre_reduce(
         self,

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -157,7 +157,7 @@ def main():
     args.prior_args = [p.get_init_args() for p in prior_models]
 
     # initialize lightning module
-    model = LNNP(args, prior_model=prior_models, mean=data.mean, std=data.std)
+    model = LNNP(args, prior_model=prior_models, mean=data.mean, std=data.std, atomref=data.atomref)
 
     checkpoint_callback = ModelCheckpoint(
         dirpath=args.log_dir,


### PR DESCRIPTION
Following #276 this PR aims at providing better support for training with relative energies while having the possibility of producing total enegies during inference.

This requires the following:
- [x] Make the Datasets provide atomic reference energies (already there via get_atomref)
- [x] Provide a mechanism to **substract** reference energies from each atom when providing samples.
I moved this from MemmappedDataset to LNNP, the samples are modifed just before being sent to the model and any Dataset that provides get_atomref is compatible with remove_ref_enegy.
- [x]  Make the TorchMD_Net model have access to the reference energies with a flag to turn on/off its **addition** (can be done via the Atomref prior)


The Atomref prior more or less provides this functionality already but requires two important changes:
- [x] The weights of its embedding layer should not be learnable (or at least have a flag)
- [x] It should be possible to turn it on/off via a flag

To train on relative energies an user has to:
- Pass the option remove_ref_energy. 
  This will send relative energies to the model and store the references as a disabled Atomref inside it.

Then, to run inference on total energies:
- call load_model with remove_ref_energy=False:
```python
model = load_model("model.ckpt", remove_ref_energy=False)
```
This will enable the Atomref instance, which sums the reference energies to the model output.

Also this PR includes the following:
- [x] Documentation
Closes #276 