### PR TITLE
Revert #292

### DIFF
--- a/torchmdnet/datasets/hdf.py
+++ b/torchmdnet/datasets/hdf.py
@@ -53,13 +53,9 @@ class HDF5(Dataset):
                             self.fields.append(("y", "energy", torch.float32))
                         if "forces" in group:
                             self.fields.append(("neg_dy", "forces", torch.float32))
-                        if "charge" in group:
-                            self.fields.append(("q", "charge", torch.float32))
-                        if "spin" in group:
-                            self.fields.append(("s", "spin", torch.float32))
                         if "partial_charges" in group:
                             self.fields.append(
-                                ("pq", "partial_charges", torch.float32)
+                                ("partial_charges", "partial_charges", torch.float32)
                             )
                         assert ("energy" in group) or (
                             "forces" in group


### PR DESCRIPTION
This reverts a change that broke the Coulomb prior.  Once #289 is merged, I'll update the HDF5 dataset to support arbitrary user defined fields.  The names of the fields will match the names of the entries in the file.