### PR TITLE
Added vector output from skew-symmetric tensor

### DIFF
--- a/tests/test_equivariance.py
+++ b/tests/test_equivariance.py
@@ -38,7 +38,7 @@ def test_vector_equivariance(model_name):
             [-0.0626055, 0.3134752, 0.9475304],
         ]
     )
-    if model_name == "equivariant_transformer"
+    if model_name == "equivariant_transformer":
         model = create_model(
             load_example_args(
                 model_name,
@@ -46,7 +46,7 @@ def test_vector_equivariance(model_name):
                 output_model="VectorOutput",
             )
         )
-    if model_name == "tensornet"
+    if model_name == "tensornet":
         model = create_model(
             load_example_args(
                 model_name,

--- a/tests/test_equivariance.py
+++ b/tests/test_equivariance.py
@@ -28,7 +28,7 @@ def test_scalar_invariance():
     torch.testing.assert_allclose(y, y_rot)
 
 
-@pytest.mark.parametrize("model_name", ["equivariant-transformer", "equivariant-tensornet"])
+@pytest.mark.parametrize("model_name", ["equivariant-transformer", "tensornet"])
 def test_vector_equivariance(model_name):
     torch.manual_seed(1234)
     rotate = torch.tensor(
@@ -38,14 +38,23 @@ def test_vector_equivariance(model_name):
             [-0.0626055, 0.3134752, 0.9475304],
         ]
     )
-
-    model = create_model(
-        load_example_args(
-            model_name,
-            prior_model=None,
-            output_model="VectorOutput",
+    if model_name == "equivariant_transformer"
+        model = create_model(
+            load_example_args(
+                model_name,
+                prior_model=None,
+                output_model="VectorOutput",
+            )
         )
-    )
+    if model_name == "tensornet"
+        model = create_model(
+            load_example_args(
+                model_name,
+                prior_model=None,
+                vector_output=True,
+                output_model="VectorOutput",
+            )
+        )
     z = torch.ones(100, dtype=torch.long)
     pos = torch.randn(100, 3)
     batch = torch.arange(50, dtype=torch.long).repeat_interleave(2)

--- a/tests/test_equivariance.py
+++ b/tests/test_equivariance.py
@@ -2,6 +2,7 @@
 # Distributed under the MIT License.
 # (See accompanying file README.md file or copy at http://opensource.org/licenses/MIT)
 
+import pytest
 import torch
 from torchmdnet.models.model import create_model
 from utils import load_example_args
@@ -27,7 +28,8 @@ def test_scalar_invariance():
     torch.testing.assert_allclose(y, y_rot)
 
 
-def test_vector_equivariance():
+@pytest.mark.parametrize("model_name", ["equivariant-transformer", "equivariant-tensornet"])
+def test_vector_equivariance(model_name):
     torch.manual_seed(1234)
     rotate = torch.tensor(
         [
@@ -39,7 +41,7 @@ def test_vector_equivariance():
 
     model = create_model(
         load_example_args(
-            "equivariant-transformer",
+            model_name,
             prior_model=None,
             output_model="VectorOutput",
         )

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from torch_geometric.data import Dataset, Data
 
 def load_example_args(model_name, remove_prior=False, config_file=None, **kwargs):
     if config_file is None:
-        if model_name == "tensornet":
+        if model_name == "tensornet" or model_name == "equivariant-tensornet":
             config_file = join(dirname(dirname(__file__)), "examples", "TensorNet-QM9.yaml")
         else:
             config_file = join(dirname(dirname(__file__)), "examples", "ET-QM9.yaml")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -10,7 +10,7 @@ from torch_geometric.data import Dataset, Data
 
 def load_example_args(model_name, remove_prior=False, config_file=None, **kwargs):
     if config_file is None:
-        if model_name == "tensornet" or model_name == "equivariant-tensornet":
+        if model_name == "tensornet":
             config_file = join(dirname(dirname(__file__)), "examples", "TensorNet-QM9.yaml")
         else:
             config_file = join(dirname(dirname(__file__)), "examples", "ET-QM9.yaml")

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -101,17 +101,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
         representation_model = TensorNet(
             equivariance_invariance_group=args["equivariance_invariance_group"],
             static_shapes=args["static_shapes"],
-            **shared_args,
-        )
-    elif args["model"] == "equivariant-tensornet":
-        from torchmdnet.models.tensornet import TensorNet
-
-        # returns an equivariant vector
-        is_equivariant = True
-        representation_model = TensorNet(
-            equivariance_invariance_group=args["equivariance_invariance_group"],
-            static_shapes=args["static_shapes"],
-            vector_output=True,
+            vector_output=args["vector_output"],
             **shared_args,
         )
     else:

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -103,6 +103,17 @@ def create_model(args, prior_model=None, mean=None, std=None):
             static_shapes=args["static_shapes"],
             **shared_args,
         )
+    elif args["model"] == "equivariant-tensornet":
+        from torchmdnet.models.tensornet import TensorNet
+
+        # returns an equivariant vector
+        is_equivariant = True
+        representation_model = TensorNet(
+            equivariance_invariance_group=args["equivariance_invariance_group"],
+            static_shapes=args["static_shapes"],
+            vector_output=True,
+            **shared_args,
+        )
     else:
         raise ValueError(f'Unknown architecture: {args["model"]}')
 

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -48,6 +48,10 @@ def vector_to_symtensor(vector):
     S = 0.5 * (tensor + tensor.transpose(-2, -1)) - I
     return S
 
+def skewtensor_to_vector(tensor):
+    '''Converts a skew-symmetric tensor to a vector.'''
+    return torch.stack((tensor[:, :, 1, 2], tensor[:, :, 2, 0], tensor[:, :, 0, 1]), dim=-1)
+
 
 def decompose_tensor(tensor):
     """Full tensor decomposition into irreducible components."""
@@ -265,10 +269,13 @@ class TensorNet(nn.Module):
         x = torch.cat((tensor_norm(I), tensor_norm(A), tensor_norm(S)), dim=-1)
         x = self.out_norm(x)
         x = self.act(self.linear((x)))
+        v = skewtensor_to_vector(A)
+        v = v.transpose(1, 2)
         # # Remove the extra atom
         if self.static_shapes:
             x = x[:-1]
-        return x, None, z, pos, batch
+            v = v[:-1]
+        return x, v, z, pos, batch
 
 
 class TensorEmbedding(nn.Module):

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -124,7 +124,7 @@ class TensorNet(nn.Module):
             (default: :obj:`True`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        vector_output (bool, optional): Whether to return 
+        vector_output (bool, optional): Whether to return vector features per atom
     """
 
     def __init__(

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -103,6 +103,7 @@ def get_argparse():
         `a[1] = a[2] = b[2] = 0`;`a[0] >= 2*cutoff, b[1] >= 2*cutoff, c[2] >= 2*cutoff`;`a[0] >= 2*b[0]`;`a[0] >= 2*c[0]`;`b[1] >= 2*c[1]`;
         These requirements correspond to a particular rotation of the system and reduced form of the vectors, as well as the requirement that the cutoff be no larger than half the box width.
     Example: [[1,0,0],[0,1,0],[0,0,1]]""")
+    parser.add_argument('--vector-output', type=bool, default=False, help='If true, returns vector features per atom on top of scalars')
     parser.add_argument('--static_shapes', type=bool, default=False, help='If true, TensorNet will use statically shaped tensors for the network, making it capturable into a CUDA graphs. In some situations static shapes can lead to a speedup, but it increases memory usage.')
 
     # other args


### PR DESCRIPTION
Allowing vector output from TensorNet. This will allow the use of `EquivariantScalar` or `EquivariantVectorOutput` from `TensorNet`.

Resolves #297.