### PR TITLE
Add SPICE 1.1.4, remove leftover remove_ref_energy in some datasets

### DIFF
--- a/torchmdnet/datasets/genentech.py
+++ b/torchmdnet/datasets/genentech.py
@@ -43,7 +43,6 @@ class GenentechTorsions(MemmappedDataset):
             transform,
             pre_transform,
             pre_filter,
-            remove_ref_energy=False,
             properties=("y"),
         )
 

--- a/torchmdnet/datasets/qm9q.py
+++ b/torchmdnet/datasets/qm9q.py
@@ -46,7 +46,6 @@ class QM9q(MemmappedDataset):
             transform,
             pre_transform,
             pre_filter,
-            remove_ref_energy=False,
             properties=("y", "neg_dy", "q", "pq", "dp"),
         )
 

--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -13,7 +13,6 @@ from tqdm import tqdm
 
 
 class SPICE(MemmappedDataset):
-
     """
     SPICE dataset (https://github.com/openmm/spice-dataset)
 
@@ -65,6 +64,10 @@ class SPICE(MemmappedDataset):
             "url": "https://zenodo.org/record/7606550/files",
             "file": "SPICE-1.1.3.hdf5",
         },
+        "1.1.4": {
+            "url": "https://zenodo.org/records/8222043/files",
+            "file": "SPICE-1.1.4.hdf5",
+        },
     }
 
     @property
@@ -103,7 +106,6 @@ class SPICE(MemmappedDataset):
             transform,
             pre_transform,
             pre_filter,
-            remove_ref_energy=False,
             properties=("y", "neg_dy"),
         )
 


### PR DESCRIPTION
- Remove bogus instances of the old remove_ref_energy.
- Added SPICE 1.1.4 to spice.py. The ET example is referencing this version, but the dataset does not allow it.