### PR TITLE
torch.compile neighbors without graph breaks

### DIFF
--- a/tests/test_neighbors.py
+++ b/tests/test_neighbors.py
@@ -9,6 +9,7 @@ import torch.jit
 import numpy as np
 from torchmdnet.models.utils import OptimizedDistance
 
+
 def sort_neighbors(neighbors, deltas, distances):
     i_sorted = np.lexsort(neighbors)
     return neighbors[:, i_sorted], deltas[i_sorted], distances[i_sorted]
@@ -69,7 +70,10 @@ def compute_ref_neighbors(pos, batch, loop, include_transpose, cutoff, box_vecto
     return ref_neighbors, ref_distance_vecs, ref_distances
 
 
-@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
+@pytest.mark.parametrize(
+    ("device", "strategy"),
+    [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")],
+)
 @pytest.mark.parametrize("n_batches", [1, 2, 3, 4, 128])
 @pytest.mark.parametrize("cutoff", [0.1, 1.0, 3.0, 4.9])
 @pytest.mark.parametrize("loop", [True, False])
@@ -92,7 +96,7 @@ def test_neighbors(
     ).to(device)
     cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
     lbox = 10.0
-    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox - 10.0*lbox
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox - 10.0 * lbox
     # Ensure there is at least one pair
     pos[0, :] = torch.zeros(3)
     pos[1, :] = torch.zeros(3)
@@ -141,7 +145,11 @@ def test_neighbors(
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
-@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
+
+@pytest.mark.parametrize(
+    ("device", "strategy"),
+    [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")],
+)
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
 @pytest.mark.parametrize("dtype", [torch.float32, torch.float64])
@@ -249,10 +257,14 @@ def test_neighbor_grads(
     else:
         assert np.allclose(ref_pos_grad_sorted, pos_grad_sorted, atol=1e-8, rtol=1e-5)
 
-@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
+
+@pytest.mark.parametrize(
+    ("device", "strategy"),
+    [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")],
+)
 @pytest.mark.parametrize("loop", [True, False])
 @pytest.mark.parametrize("include_transpose", [True, False])
-@pytest.mark.parametrize("num_atoms", [1,2,10])
+@pytest.mark.parametrize("num_atoms", [1, 2, 10])
 @pytest.mark.parametrize("box_type", [None, "triclinic", "rectangular"])
 def test_neighbor_autograds(
     device, strategy, loop, include_transpose, num_atoms, box_type
@@ -293,8 +305,12 @@ def test_neighbor_autograds(
     neighbors, distances, deltas = nl(positions, batch)
     # Lambda that returns only the distances and deltas
     lambda_dist = lambda x, y: nl(x, y)[1:]
-    torch.autograd.gradcheck(lambda_dist, (positions, batch), eps=1e-4, atol=1e-4, rtol=1e-4, nondet_tol=1e-4)
-    torch.autograd.gradgradcheck(lambda_dist, (positions, batch), eps=1e-4, atol=1e-4, rtol=1e-4, nondet_tol=1e-4)
+    torch.autograd.gradcheck(
+        lambda_dist, (positions, batch), eps=1e-4, atol=1e-4, rtol=1e-4, nondet_tol=1e-4
+    )
+    torch.autograd.gradgradcheck(
+        lambda_dist, (positions, batch), eps=1e-5, atol=1e-4, rtol=1e-4, nondet_tol=1e-3
+    )
 
 
 @pytest.mark.parametrize("strategy", ["brute", "cell", "shared"])
@@ -353,7 +369,11 @@ def test_large_size(strategy, n_batches):
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
-@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")])
+
+@pytest.mark.parametrize(
+    ("device", "strategy"),
+    [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared"), ("cuda", "cell")],
+)
 @pytest.mark.parametrize("n_batches", [1, 128])
 @pytest.mark.parametrize("cutoff", [1.0])
 @pytest.mark.parametrize("loop", [True, False])
@@ -504,6 +524,7 @@ def test_cuda_graph_compatible_forward(
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
 
+
 @pytest.mark.parametrize("device", ["cuda"])
 @pytest.mark.parametrize("strategy", ["brute", "shared", "cell"])
 @pytest.mark.parametrize("n_batches", [1, 128])
@@ -578,12 +599,12 @@ def test_cuda_graph_compatible_backward(
         torch.cuda.synchronize()
 
 
-@pytest.mark.parametrize(("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared")])
+@pytest.mark.parametrize(
+    ("device", "strategy"), [("cpu", "brute"), ("cuda", "brute"), ("cuda", "shared")]
+)
 @pytest.mark.parametrize("n_batches", [1, 128])
 @pytest.mark.parametrize("use_forward", [True, False])
-def test_per_batch_box(
-    device, strategy, n_batches, use_forward
-):
+def test_per_batch_box(device, strategy, n_batches, use_forward):
     dtype = torch.float32
     cutoff = 1.0
     include_transpose = True
@@ -599,7 +620,7 @@ def test_per_batch_box(
     ).to(device)
     cumsum = np.cumsum(np.concatenate([[0], n_atoms_per_batch]))
     lbox = 10.0
-    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox - 10.0*lbox
+    pos = torch.rand(cumsum[-1], 3, device=device, dtype=dtype) * lbox - 10.0 * lbox
     # Ensure there is at least one pair
     pos[0, :] = torch.zeros(3)
     pos[1, :] = torch.zeros(3)
@@ -625,7 +646,9 @@ def test_per_batch_box(
         include_transpose=include_transpose,
     )
     batch.to(device)
-    neighbors, distances, distance_vecs = nl(pos, batch, box=box if use_forward else None)
+    neighbors, distances, distance_vecs = nl(
+        pos, batch, box=box if use_forward else None
+    )
     neighbors = neighbors.cpu().detach().numpy()
     distance_vecs = distance_vecs.cpu().detach().numpy()
     distances = distances.cpu().detach().numpy()
@@ -639,3 +662,45 @@ def test_per_batch_box(
     assert np.allclose(neighbors, ref_neighbors)
     assert np.allclose(distances, ref_distances)
     assert np.allclose(distance_vecs, ref_distance_vecs)
+
+
+@pytest.mark.parametrize("device", ["cpu", "cuda"])
+@pytest.mark.parametrize("dtype", [torch.float64])
+@pytest.mark.parametrize("loop", [True, False])
+@pytest.mark.parametrize("include_transpose", [True, False])
+def test_torch_compile(device, dtype, loop, include_transpose):
+    if torch.__version__ < "2.0.0":
+        pytest.skip("Not available in this version")
+    if device == "cuda" and not torch.cuda.is_available():
+        pytest.skip("CUDA not available")
+    np.random.seed(123456)
+    example_pos = 10 * torch.rand(50, 3, requires_grad=True, dtype=dtype, device=device)
+    model = OptimizedDistance(
+        cutoff_lower=0.1,  # I do this to avoid non-finite-differentiable points
+        cutoff_upper=10,
+        return_vecs=True,
+        loop=loop,
+        max_num_pairs=-example_pos.shape[0],
+        include_transpose=include_transpose,
+        resize_to_fit=False,
+        check_errors=False,
+    ).to(device)
+    for _ in range(50):
+        model(example_pos)
+    edge_index, edge_vec, edge_distance = model(example_pos)
+    edge_vec.sum().backward()
+    example_pos.grad = None
+    fullgraph = torch.__version__ >= "2.2.0"
+    model = torch.compile(
+        model,
+        fullgraph=fullgraph,
+        backend="inductor",
+        mode="reduce-overhead",
+    )
+    edge_index, edge_vec, edge_distance = model(example_pos)
+    edge_vec.sum().backward()
+    example_pos.grad = None
+    lambda_dist = lambda x: model(x)[1:]
+    torch.autograd.gradcheck(
+        lambda_dist, example_pos, eps=1e-4, atol=1e-4, rtol=1e-4, nondet_tol=1e-4
+    )

--- a/torchmdnet/extensions/__init__.py
+++ b/torchmdnet/extensions/__init__.py
@@ -8,6 +8,7 @@
 import os.path as osp
 import torch
 import importlib.machinery
+from torch import Tensor
 from typing import Tuple
 
 
@@ -45,18 +46,17 @@ def is_current_stream_capturing():
 
 def get_neighbor_pairs_kernel(
     strategy: str,
-    positions: torch.Tensor,
-    batch: torch.Tensor,
-    box_vectors: torch.Tensor,
+    positions: Tensor,
+    batch: Tensor,
+    box_vectors: Tensor,
     use_periodic: bool,
     cutoff_lower: float,
     cutoff_upper: float,
     max_num_pairs: int,
     loop: bool,
     include_transpose: bool,
-) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     """Computes the neighbor pairs for a given set of atomic positions.
-
     The list is generated as a list of pairs (i,j) without any enforced ordering.
     The list is padded with -1 to the maximum number of pairs.
 
@@ -64,11 +64,11 @@ def get_neighbor_pairs_kernel(
     ----------
     strategy : str
         Strategy to use for computing the neighbor list. Can be one of :code:`["shared", "brute", "cell"]`.
-    positions : torch.Tensor
+    positions : Tensor
         A tensor with shape (N, 3) representing the atomic positions.
-    batch : torch.Tensor
+    batch : Tensor
         A tensor with shape (N,). Specifies the batch for each atom.
-    box_vectors : torch.Tensor
+    box_vectors : Tensor
         The vectors defining the periodic box with shape `(3, 3)` or `(max(batch)+1, 3, 3)` if a different box is used for each sample.
     use_periodic : bool
         Whether to apply periodic boundary conditions.
@@ -85,13 +85,13 @@ def get_neighbor_pairs_kernel(
 
     Returns
     -------
-    neighbors : torch.Tensor
+    neighbors : Tensor
         List of neighbors for each atom. Shape (2, max_num_pairs).
-    distances : torch.Tensor
+    distances : Tensor
         List of distances for each atom. Shape (max_num_pairs,).
-    distance_vecs : torch.Tensor
+    distance_vecs : Tensor
         List of distance vectors for each atom. Shape (max_num_pairs, 3).
-    num_pairs : torch.Tensor
+    num_pairs : Tensor
         The number of pairs found.
 
     Notes

--- a/torchmdnet/extensions/__init__.py
+++ b/torchmdnet/extensions/__init__.py
@@ -137,10 +137,10 @@ def get_neighbor_pairs_fwd_meta(
 ) -> Tuple[Tensor, Tensor, Tensor, Tensor]:
     """Returns empty vectors with the correct shape for the output of get_neighbor_pairs_kernel."""
     size = max_num_pairs
-    edge_index = torch.empty((2, size), dtype=torch.long, device=positions.device)
+    edge_index = torch.empty((2, size), dtype=torch.int, device=positions.device)
     edge_distance = torch.empty((size,), dtype=positions.dtype, device=positions.device)
     edge_vec = torch.empty((size, 3), dtype=positions.dtype, device=positions.device)
-    num_pairs = torch.empty((1,), dtype=torch.long, device=positions.device)
+    num_pairs = torch.empty((1,), dtype=torch.int, device=positions.device)
     return edge_index, edge_vec, edge_distance, num_pairs
 
 

--- a/torchmdnet/extensions/__init__.py
+++ b/torchmdnet/extensions/__init__.py
@@ -30,6 +30,8 @@ def _load_library(library):
 
 _load_library("torchmdnet_extensions")
 
+__all__ = ["is_current_stream_capturing", "get_neighbor_pairs_kernel"]
+
 
 def is_current_stream_capturing():
     """Returns True if the current CUDA stream is capturing.

--- a/torchmdnet/extensions/neighbors/common.cuh
+++ b/torchmdnet/extensions/neighbors/common.cuh
@@ -34,7 +34,7 @@ inline Accessor<scalar_t, num_dims> get_accessor(const Tensor& tensor) {
     return tensor.packed_accessor32<scalar_t, num_dims, torch::RestrictPtrTraits>();
 };
 
-template <typename scalar_t> __device__ __forceinline__ scalar_t sqrt_(scalar_t x){};
+template <typename scalar_t> __device__ __forceinline__ scalar_t sqrt_(scalar_t x){return ::sqrt(x);};
 template <> __device__ __forceinline__ float sqrt_(float x) {
     return ::sqrtf(x);
 };

--- a/torchmdnet/extensions/neighbors/neighbors_cpu.cpp
+++ b/torchmdnet/extensions/neighbors/neighbors_cpu.cpp
@@ -1,7 +1,7 @@
 /* Copyright Universitat Pompeu Fabra 2020-2023  https://www.compscience.org
  * Distributed under the MIT License.
  *(See accompanying file README.md file or copy at http://opensource.org/licenses/MIT)
-*/
+ */
 #include <torch/extension.h>
 #include <tuple>
 
@@ -18,19 +18,22 @@ using torch::round;
 using torch::Scalar;
 using torch::Tensor;
 using torch::vstack;
+using torch::autograd::AutogradContext;
+using torch::autograd::Function;
+using torch::autograd::tensor_list;
 using torch::indexing::None;
 using torch::indexing::Slice;
 
 static tuple<Tensor, Tensor, Tensor, Tensor>
-forward(const Tensor& positions, const Tensor& batch, const Tensor& in_box_vectors,
-        bool use_periodic, const Scalar& cutoff_lower, const Scalar& cutoff_upper,
-        const Scalar& max_num_pairs, bool loop, bool include_transpose) {
+forward_impl(const std::string& strategy, const Tensor& positions, const Tensor& batch,
+             const Tensor& in_box_vectors, bool use_periodic, const Scalar& cutoff_lower,
+             const Scalar& cutoff_upper, const Scalar& max_num_pairs, bool loop,
+             bool include_transpose) {
     TORCH_CHECK(positions.dim() == 2, "Expected \"positions\" to have two dimensions");
     TORCH_CHECK(positions.size(0) > 0,
                 "Expected the 1nd dimension size of \"positions\" to be more than 0");
     TORCH_CHECK(positions.size(1) == 3, "Expected the 2nd dimension size of \"positions\" to be 3");
     TORCH_CHECK(positions.is_contiguous(), "Expected \"positions\" to be contiguous");
-
     TORCH_CHECK(cutoff_upper.to<double>() > 0, "Expected \"cutoff\" to be positive");
     Tensor box_vectors = in_box_vectors;
     const int n_batch = batch.max().item<int>() + 1;
@@ -44,7 +47,8 @@ forward(const Tensor& positions, const Tensor& batch, const Tensor& in_box_vecto
         // Ensure the box first dimension has size max(batch) + 1
         TORCH_CHECK(box_vectors.size(0) == n_batch,
                     "Expected \"box_vectors\" to have shape (n_batch, 3, 3)");
-	// Check that the box is a valid triclinic box, in the case of a box per sample we only check the first one
+        // Check that the box is a valid triclinic box, in the case of a box per sample we only
+        // check the first one
         double v[3][3];
         for (int i = 0; i < 3; i++)
             for (int j = 0; j < 3; j++)
@@ -113,16 +117,119 @@ forward(const Tensor& positions, const Tensor& batch, const Tensor& in_box_vecto
     }
     Tensor num_pairs_found = torch::empty(1, distances.options().dtype(kInt32));
     num_pairs_found[0] = distances.size(0);
+    //This seems wasteful, but it allows to enable torch.compile by guaranteeing that the output of this operator has a predictable size
+    //Resize to max_num_pairs, add zeros if necessary
+    deltas = torch::vstack({deltas, torch::zeros({max_num_pairs.toLong() - num_pairs_found[0].item<int>(), 3}, deltas.options())});
+    distances = torch::hstack({distances, torch::zeros({max_num_pairs.toLong() - num_pairs_found[0].item<int>()}, distances.options())});
+    //For the neighbors add (-1,-1) pairs to fill the tensor
+    neighbors = torch::hstack({neighbors, torch::full({2, max_num_pairs.toLong() - num_pairs_found[0].item<int>()}, -1, neighbors.options().dtype(kInt32))});
     return {neighbors, deltas, distances, num_pairs_found};
 }
 
-TORCH_LIBRARY_IMPL(torchmdnet_extensions, CPU, m) {
+// The backwards operation is implemented fully in pytorch so that it can be differentiated a second
+// time automatically via Autograd.
+static Tensor backward_impl(const Tensor& grad_edge_vec, const Tensor& grad_edge_weight,
+                            const Tensor& edge_index, const Tensor& edge_vec,
+                            const Tensor& edge_weight, const int64_t num_atoms) {
+    auto zero_mask = edge_weight.eq(0);
+    auto zero_mask3 = zero_mask.unsqueeze(-1).expand_as(grad_edge_vec);
+    // We need to avoid dividing by 0. Otherwise Autograd fills the gradient with NaNs in the
+    // case of a double backwards. This is why we index_select like this.
+    auto grad_distances_ = edge_vec / edge_weight.masked_fill(zero_mask, 1).unsqueeze(-1) *
+                           grad_edge_weight.masked_fill(zero_mask, 0).unsqueeze(-1);
+    auto result = grad_edge_vec.masked_fill(zero_mask3, 0) + grad_distances_;
+    // Given that there is no masked_index_add function, in order to make the operation
+    // CUDA-graph compatible I need to transform masked indices into a dummy value (num_atoms)
+    // and then exclude that value from the output.
+    // TODO: replace this once masked_index_add  or masked_scatter_add are available
+    auto grad_positions_ = torch::zeros({num_atoms + 1, 3}, edge_vec.options());
+    auto edge_index_ =
+        edge_index.masked_fill(zero_mask.unsqueeze(0).expand_as(edge_index), num_atoms);
+    grad_positions_.index_add_(0, edge_index_[0], result);
+    grad_positions_.index_add_(0, edge_index_[1], -result);
+    auto grad_positions = grad_positions_.index({Slice(0, num_atoms), Slice()});
+    return grad_positions;
+}
+
+// This is the autograd function that is called when the user calls get_neighbor_pairs.
+// It dispatches the required strategy for the forward function and implements the backward
+// function. The backward function is written in full pytorch so that it can be differentiated a
+// second time automatically via Autograd.
+class NeighborAutograd : public torch::autograd::Function<NeighborAutograd> {
+public:
+    static tensor_list forward(AutogradContext* ctx, const std::string& strategy,
+                               const Tensor& positions, const Tensor& batch,
+                               const Tensor& box_vectors, bool use_periodic,
+                               const Scalar& cutoff_lower, const Scalar& cutoff_upper,
+                               const Scalar& max_num_pairs, bool loop, bool include_transpose) {
+        static auto fwd =
+            torch::Dispatcher::singleton()
+                .findSchemaOrThrow("torchmdnet_extensions::get_neighbor_pairs_fwd", "")
+                .typed<decltype(forward_impl)>();
+        Tensor neighbors, deltas, distances, i_curr_pair;
+        std::tie(neighbors, deltas, distances, i_curr_pair) =
+            fwd.call(strategy, positions, batch, box_vectors, use_periodic, cutoff_lower,
+                     cutoff_upper, max_num_pairs, loop, include_transpose);
+        ctx->save_for_backward({neighbors, deltas, distances});
+        ctx->saved_data["num_atoms"] = positions.size(0);
+        return {neighbors, deltas, distances, i_curr_pair};
+    }
+
+    using Slice = torch::indexing::Slice;
+
+    static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
+        auto saved = ctx->get_saved_variables();
+        auto edge_index = saved[0];
+        auto edge_vec = saved[1];
+        auto edge_weight = saved[2];
+        auto num_atoms = ctx->saved_data["num_atoms"].toInt();
+        auto grad_edge_vec = grad_outputs[1];
+        auto grad_edge_weight = grad_outputs[2];
+        static auto backward =
+            torch::Dispatcher::singleton()
+                .findSchemaOrThrow("torchmdnet_extensions::get_neighbor_pairs_bkwd", "")
+                .typed<decltype(backward_impl)>();
+        auto grad_positions = backward.call(grad_edge_vec, grad_edge_weight, edge_index, edge_vec,
+                                            edge_weight, num_atoms);
+        Tensor ignore;
+        return {ignore, grad_positions, ignore, ignore, ignore, ignore,
+                ignore, ignore,         ignore, ignore, ignore};
+    }
+};
+
+// By registering as a CompositeImplicitAutograd we can torch.compile this Autograd function.
+// This mode will generate meta registration for NeighborAutograd automatically, in this case using
+// the
+//  meta registrations provided for the forward and backward functions python side.
+// We provide meta registrations python side because it is the recommended way to do it.
+TORCH_LIBRARY_IMPL(torchmdnet_extensions, CompositeImplicitAutograd, m) {
     m.impl("get_neighbor_pairs",
            [](const std::string& strategy, const Tensor& positions, const Tensor& batch,
               const Tensor& box_vectors, bool use_periodic, const Scalar& cutoff_lower,
               const Scalar& cutoff_upper, const Scalar& max_num_pairs, bool loop,
               bool include_transpose) {
-               return forward(positions, batch, box_vectors, use_periodic, cutoff_lower,
-                              cutoff_upper, max_num_pairs, loop, include_transpose);
+               auto result = NeighborAutograd::apply(strategy, positions, batch, box_vectors,
+                                                     use_periodic, cutoff_lower, cutoff_upper,
+                                                     max_num_pairs, loop, include_transpose);
+               return std::make_tuple(result[0], result[1], result[2], result[3]);
            });
+}
+
+// The registration for the CUDA version of the forward function is done in a separate .cu file.
+TORCH_LIBRARY_IMPL(torchmdnet_extensions, CPU, m) {
+    m.impl("get_neighbor_pairs_fwd", forward_impl);
+}
+
+// Ideally we would register this just once using CompositeImplicitAutograd, but this causes a
+// segfault
+//  when trying to torch.compile this function.
+// Doing it this way prints a message about Autograd not being provided a backward function of the
+// backward function. It gets it from the implementation just fine now, but warns that in the future
+// this will be deprecated.
+TORCH_LIBRARY_IMPL(torchmdnet_extensions, CPU, m) {
+    m.impl("get_neighbor_pairs_bkwd", backward_impl);
+}
+
+TORCH_LIBRARY_IMPL(torchmdnet_extensions, CUDA, m) {
+    m.impl("get_neighbor_pairs_bkwd", backward_impl);
 }

--- a/torchmdnet/extensions/neighbors/neighbors_cuda.cu
+++ b/torchmdnet/extensions/neighbors/neighbors_cuda.cu
@@ -8,84 +8,30 @@
 #include "neighbors_cuda_cell.cuh"
 #include "neighbors_cuda_shared.cuh"
 #include <torch/extension.h>
-template <class... T> auto call_forward_kernel(const std::string& kernel_name, const T&... args) {
-    if (kernel_name == "brute") {
-        return forward_brute(args...);
-    } else if (kernel_name == "cell") {
-        return forward_cell(args...);
-    } else if (kernel_name == "shared") {
-        return forward_shared(args...);
+static std::tuple<Tensor, Tensor, Tensor, Tensor>
+forward_impl_cuda(const std::string& strategy, const Tensor& positions, const Tensor& batch,
+                  const Tensor& in_box_vectors, bool use_periodic, const Scalar& cutoff_lower,
+                  const Scalar& cutoff_upper, const Scalar& max_num_pairs, bool loop,
+                  bool include_transpose) {
+    auto kernel = forward_brute;
+    if (positions.size(0) >= 32768 && strategy == "brute") {
+        kernel = forward_shared;
+    }
+    if (strategy == "brute") {
+    } else if (strategy == "cell") {
+        kernel = forward_cell;
+    } else if (strategy == "shared") {
+        kernel = forward_shared;
     } else {
         throw std::runtime_error("Unknown kernel name");
     }
+    return kernel(positions, batch, in_box_vectors, use_periodic, cutoff_lower, cutoff_upper,
+                  max_num_pairs, loop, include_transpose);
 }
 
-// This is the autograd function that is called when the user calls get_neighbor_pairs.
-// It dispatches the required strategy for the forward function and implements the backward
-// function. The backward function is written in full pytorch so that it can be differentiated a
-// second time automatically via Autograd.
-class NeighborAutograd : public torch::autograd::Function<NeighborAutograd> {
-public:
-    static tensor_list forward(AutogradContext* ctx, const std::string& strategy,
-                               const Tensor& positions, const Tensor& batch,
-                               const Tensor& box_vectors, bool use_periodic,
-                               const Scalar& cutoff_lower, const Scalar& cutoff_upper,
-                               const Scalar& max_num_pairs, bool loop, bool include_transpose) {
-        Tensor neighbors, deltas, distances, i_curr_pair;
-        std::tie(neighbors, deltas, distances, i_curr_pair) =
-            call_forward_kernel(strategy, positions, batch, box_vectors, use_periodic, cutoff_lower,
-                                cutoff_upper, max_num_pairs, loop, include_transpose);
-        ctx->save_for_backward({neighbors, deltas, distances});
-        ctx->saved_data["num_atoms"] = positions.size(0);
-        return {neighbors, deltas, distances, i_curr_pair};
-    }
-
-    using Slice = torch::indexing::Slice;
-
-    static tensor_list backward(AutogradContext* ctx, tensor_list grad_outputs) {
-        auto saved = ctx->get_saved_variables();
-        auto edge_index = saved[0];
-        auto edge_vec = saved[1];
-        auto edge_weight = saved[2];
-        auto num_atoms = ctx->saved_data["num_atoms"].toInt();
-        auto grad_edge_vec = grad_outputs[1];
-        auto grad_edge_weight = grad_outputs[2];
-        auto zero_mask = edge_weight == 0;
-        auto zero_mask3 = zero_mask.unsqueeze(-1).expand_as(grad_edge_vec);
-        // We need to avoid dividing by 0. Otherwise Autograd fills the gradient with NaNs in the
-        // case of a double backwards. This is why we index_select like this.
-        auto grad_distances_ = edge_vec / edge_weight.masked_fill(zero_mask, 1).unsqueeze(-1) *
-                               grad_edge_weight.masked_fill(zero_mask, 0).unsqueeze(-1);
-        auto result = grad_edge_vec.masked_fill(zero_mask3, 0) + grad_distances_;
-        // Given that there is no masked_index_add function, in order to make the operation
-        // CUDA-graph compatible I need to transform masked indices into a dummy value (num_atoms)
-        // and then exclude that value from the output.
-	// TODO: replace this once masked_index_add  or masked_scatter_add are available
-        auto grad_positions_ = torch::zeros({num_atoms + 1, 3}, edge_vec.options());
-        auto edge_index_ =
-            edge_index.masked_fill(zero_mask.unsqueeze(0).expand_as(edge_index), num_atoms);
-        grad_positions_.index_add_(0, edge_index_[0], result);
-        grad_positions_.index_add_(0, edge_index_[1], -result);
-        auto grad_positions = grad_positions_.index({Slice(0, num_atoms), Slice()});
-        Tensor ignore;
-        return {ignore, grad_positions, ignore, ignore, ignore, ignore,
-                ignore, ignore,         ignore, ignore, ignore};
-    }
-};
-
-TORCH_LIBRARY_IMPL(torchmdnet_extensions, AutogradCUDA, m) {
-    m.impl("get_neighbor_pairs",
-           [](const std::string& strategy, const Tensor& positions, const Tensor& batch,
-              const Tensor& box_vectors, bool use_periodic, const Scalar& cutoff_lower,
-              const Scalar& cutoff_upper, const Scalar& max_num_pairs, bool loop,
-              bool include_transpose) {
-               auto final_strategy = strategy;
-               if (positions.size(0) >= 32768 && strategy == "brute") {
-                   final_strategy = "shared";
-               }
-               auto result = NeighborAutograd::apply(final_strategy, positions, batch, box_vectors,
-                                                     use_periodic, cutoff_lower, cutoff_upper,
-                                                     max_num_pairs, loop, include_transpose);
-               return std::make_tuple(result[0], result[1], result[2], result[3]);
-           });
+// We only need to register the CUDA version of the forward function here. This way we can avoid
+// compiling this file in CPU-only mode The rest of the registrations take place in
+// neighbors_cpu.cpp
+TORCH_LIBRARY_IMPL(torchmdnet_extensions, CUDA, m) {
+    m.impl("get_neighbor_pairs_fwd", forward_impl_cuda);
 }

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -118,69 +118,70 @@ class NeighborEmbedding(nn.Module):
 
 
 class OptimizedDistance(torch.nn.Module):
-    """ Compute the neighbor list for a given cutoff.
+    """Compute the neighbor list for a given cutoff.
 
-        This operation can be placed inside a CUDA graph in some cases.
-        In particular, resize_to_fit and check_errors must be False.
+    This operation can be placed inside a CUDA graph in some cases.
+    In particular, resize_to_fit and check_errors must be False.
 
-        Note that this module returns neighbors such that :math:`r_{ij} \\ge \\text{cutoff_lower}\\quad\\text{and}\\quad r_{ij} < \\text{cutoff_upper}`.
+    Note that this module returns neighbors such that :math:`r_{ij} \\ge \\text{cutoff_lower}\\quad\\text{and}\\quad r_{ij} < \\text{cutoff_upper}`.
 
-        This function optionally supports periodic boundary conditions with
-        arbitrary triclinic boxes.  The box vectors `a`, `b`, and `c` must satisfy
-        certain requirements:
+    This function optionally supports periodic boundary conditions with
+    arbitrary triclinic boxes.  The box vectors `a`, `b`, and `c` must satisfy
+    certain requirements:
 
-        .. code:: python
+    .. code:: python
 
-           a[1] = a[2] = b[2] = 0
-           a[0] >= 2*cutoff, b[1] >= 2*cutoff, c[2] >= 2*cutoff
-           a[0] >= 2*b[0]
-           a[0] >= 2*c[0]
-           b[1] >= 2*c[1]
+       a[1] = a[2] = b[2] = 0
+       a[0] >= 2*cutoff, b[1] >= 2*cutoff, c[2] >= 2*cutoff
+       a[0] >= 2*b[0]
+       a[0] >= 2*c[0]
+       b[1] >= 2*c[1]
 
-        These requirements correspond to a particular rotation of the system and
-        reduced form of the vectors, as well as the requirement that the cutoff be
-        no larger than half the box width.
+    These requirements correspond to a particular rotation of the system and
+    reduced form of the vectors, as well as the requirement that the cutoff be
+    no larger than half the box width.
 
-        Parameters
-        ----------
-        cutoff_lower : float
-            Lower cutoff for the neighbor list.
-        cutoff_upper : float
-            Upper cutoff for the neighbor list.
-        max_num_pairs : int
-            Maximum number of pairs to store, if the number of pairs found is less than this, the list is padded with (-1,-1) pairs up to max_num_pairs unless resize_to_fit is True, in which case the list is resized to the actual number of pairs found.
-            If the number of pairs found is larger than this, the pairs are randomly sampled. When check_errors is True, an exception is raised in this case.
-            If negative, it is interpreted as (minus) the maximum number of neighbors per atom.
-        strategy : str
-            Strategy to use for computing the neighbor list. Can be one of :code:`["shared", "brute", "cell"]`.
+    Parameters
+    ----------
+    cutoff_lower : float
+        Lower cutoff for the neighbor list.
+    cutoff_upper : float
+        Upper cutoff for the neighbor list.
+    max_num_pairs : int
+        Maximum number of pairs to store, if the number of pairs found is less than this, the list is padded with (-1,-1) pairs up to max_num_pairs unless resize_to_fit is True, in which case the list is resized to the actual number of pairs found.
+        If the number of pairs found is larger than this, the pairs are randomly sampled. When check_errors is True, an exception is raised in this case.
+        If negative, it is interpreted as (minus) the maximum number of neighbors per atom.
+    strategy : str
+        Strategy to use for computing the neighbor list. Can be one of :code:`["shared", "brute", "cell"]`.
 
-            1. *Shared*: An O(N^2) algorithm that leverages CUDA shared memory, best for large number of particles.
-            2. *Brute*: A brute force O(N^2) algorithm, best for small number of particles.
-            3. *Cell*:  A cell list algorithm, best for large number of particles, low cutoffs and low batch size.
-        box : torch.Tensor, optional
-            The vectors defining the periodic box.  This must have shape `(3, 3)` or `(max(batch)+1, 3, 3)` if a ox per sample is desired.
-            where `box_vectors[0] = a`, `box_vectors[1] = b`, and `box_vectors[2] = c`.
-            If this is omitted, periodic boundary conditions are not applied.
-        loop : bool, optional
-            Whether to include self-interactions.
-            Default: False
-        include_transpose : bool, optional
-            Whether to include the transpose of the neighbor list.
-            Default: True
-        resize_to_fit : bool, optional
-            Whether to resize the neighbor list to the actual number of pairs found. When False, the list is padded with (-1,-1) pairs up to max_num_pairs
-            Default: True
-            If this is True the operation is not CUDA graph compatible.
-        check_errors : bool, optional
-            Whether to check for too many pairs. If this is True the operation is not CUDA graph compatible.
-            Default: True
-        return_vecs : bool, optional
-            Whether to return the distance vectors.
-            Default: False
-        long_edge_index : bool, optional
-            Whether to return edge_index as int64, otherwise int32.
-            Default: True
-        """
+        1. *Shared*: An O(N^2) algorithm that leverages CUDA shared memory, best for large number of particles.
+        2. *Brute*: A brute force O(N^2) algorithm, best for small number of particles.
+        3. *Cell*:  A cell list algorithm, best for large number of particles, low cutoffs and low batch size.
+    box : torch.Tensor, optional
+        The vectors defining the periodic box.  This must have shape `(3, 3)` or `(max(batch)+1, 3, 3)` if a ox per sample is desired.
+        where `box_vectors[0] = a`, `box_vectors[1] = b`, and `box_vectors[2] = c`.
+        If this is omitted, periodic boundary conditions are not applied.
+    loop : bool, optional
+        Whether to include self-interactions.
+        Default: False
+    include_transpose : bool, optional
+        Whether to include the transpose of the neighbor list.
+        Default: True
+    resize_to_fit : bool, optional
+        Whether to resize the neighbor list to the actual number of pairs found. When False, the list is padded with (-1,-1) pairs up to max_num_pairs
+        Default: True
+        If this is True the operation is not CUDA graph compatible.
+    check_errors : bool, optional
+        Whether to check for too many pairs. If this is True the operation is not CUDA graph compatible.
+        Default: True
+    return_vecs : bool, optional
+        Whether to return the distance vectors.
+        Default: False
+    long_edge_index : bool, optional
+        Whether to return edge_index as int64, otherwise int32.
+        Default: True
+    """
+
     def __init__(
         self,
         cutoff_lower=0.0,
@@ -193,7 +194,7 @@ class OptimizedDistance(torch.nn.Module):
         resize_to_fit=True,
         check_errors=True,
         box=None,
-        long_edge_index=True
+        long_edge_index=True,
     ):
         super(OptimizedDistance, self).__init__()
         self.cutoff_upper = cutoff_upper
@@ -212,14 +213,16 @@ class OptimizedDistance(torch.nn.Module):
             if self.strategy == "cell":
                 # Default the box to 3 times the cutoff, really inefficient for the cell list
                 lbox = cutoff_upper * 3.0
-                self.box = torch.tensor([[lbox, 0, 0], [0, lbox, 0], [0, 0, lbox]], device="cpu")
+                self.box = torch.tensor(
+                    [[lbox, 0, 0], [0, lbox, 0], [0, 0, lbox]], device="cpu"
+                )
         if self.strategy == "cell":
             self.box = self.box.cpu()
         self.check_errors = check_errors
         self.long_edge_index = long_edge_index
 
     def forward(
-            self, pos: Tensor, batch: Optional[Tensor] = None, box: Optional[Tensor] = None
+        self, pos: Tensor, batch: Optional[Tensor] = None, box: Optional[Tensor] = None
     ) -> Tuple[Tensor, Tensor, Optional[Tensor]]:
         """
         Compute the neighbor list for a given cutoff.
@@ -255,7 +258,7 @@ class OptimizedDistance(torch.nn.Module):
         box = self.box if box is None else box
         assert box is not None, "Box must be provided"
         box = box.to(pos.dtype)
-        max_pairs : int = self.max_num_pairs
+        max_pairs: int = self.max_num_pairs
         if self.max_num_pairs < 0:
             max_pairs = -self.max_num_pairs * pos.shape[0]
         if batch is None:
@@ -273,12 +276,10 @@ class OptimizedDistance(torch.nn.Module):
             use_periodic=use_periodic,
         )
         if self.check_errors:
-            if num_pairs[0] > max_pairs:
-                raise AssertionError(
-                    "Found num_pairs({}) > max_num_pairs({})".format(
-                        num_pairs[0], max_pairs
-                    )
-                )
+            assert (
+                num_pairs[0] <= max_pairs
+            ), f"Found num_pairs({num_pairs[0]}) > max_num_pairs({max_pairs})"
+
         # Remove (-1,-1)  pairs
         if self.resize_to_fit:
             mask = edge_index[0] != -1


### PR DESCRIPTION
Pytorch introduced a new API to handle extensions, it is "documented" here: https://docs.google.com/document/d/1_W62p8WJOQQUzPsJYa7s701JXt0qf2OfLub2sbkHOaU/edit

It makes it possible to write meta registrations for C++ extensions, which I could not make before. With a meta registration torch.compile is able to understand custom operations. A meta registration is an implementation of the operator for the "meta" device (akin to CPU or CUDA), in which tensors only have shapes and are refered to as FakeTensor.
It is used by pytorch to gather information about the input/output shapes of an operator for compilation purposes.
 

Makes this code possible:
```python
    example_pos = 100 * torch.rand(
        50, 3, requires_grad=True, dtype=dtype, device=device
    )
    model = OptimizedDistance(
        return_vecs=True,
        loop=True,
        max_num_pairs=-50,
        include_transpose=True,
        resize_to_fit=False,
        check_errors=False,
    ).to(device)
    for _ in range(25):
        model(example_pos)
    edge_index, edge_vec, edge_distance = model(example_pos)
    model = torch.compile(
        model,
        fullgraph=True,
        backend="inductor",
        mode="reduce-overhead",
    )
    edge_index, edge_vec, edge_distance = model(example_pos)
```
Prior to this PR torch.compile had to be instructed to exclude the nieghbor extension from the operation graph:
https://github.com/torchmd/torchmd-net/blob/fae79bd9e8e96ab235c52d5e54e33c3be9e4d05d/torchmdnet/extensions/__init__.py#L116-L118

So it could not be compiled with `fullgraph=True`.

The new API starts at version 2.2.1, which is not yet in conda-forge. I made it so that the current behavior is unchanged for versions prior to it.

Still compile is not able to handle code like this, in which a particular item from a tensor is accessed.
```python
        if self.check_errors:
            assert (
                num_pairs[0] <= max_pairs
            ), f"Found num_pairs({num_pairs[0]}) > max_num_pairs({max_pairs})"
```
It can still be compiled, just not with fullgraph=True.
The general rule being "if you can capture it into a CUDA graph you can torch.compile it"