### PR TITLE
[WIP] Introduce additional_labels

### DIFF
--- a/tests/test_model.py
+++ b/tests/test_model.py
@@ -18,22 +18,24 @@ from utils import load_example_args, create_example_batch
 
 @mark.parametrize("model_name", models.__all_models__)
 @mark.parametrize("use_batch", [True, False])
-@mark.parametrize("explicit_q_s", [True, False])
+@mark.parametrize("use_extra_args", [True, False])
 @mark.parametrize("precision", [32, 64])
-def test_forward(model_name, use_batch, explicit_q_s, precision):
+@mark.parametrize("additional_labels", [None, {"tensornet_q": {"label": "total_charge", 'learnable': False, 'init_value': 0.1}}])
+def test_forward(model_name, use_batch, use_extra_args, precision, additional_labels):
     z, pos, batch = create_example_batch()
     pos = pos.to(dtype=dtype_mapping[precision])
-    model = create_model(load_example_args(model_name, prior_model=None, precision=precision))
+    model = create_model(load_example_args(model_name, prior_model=None, precision=precision, additional_labels=additional_labels))
     batch = batch if use_batch else None
-    if explicit_q_s:
-        model(z, pos, batch=batch, q=None, s=None)
+    if use_extra_args:
+        model(z, pos, batch=batch, extra_args={'total_charge': torch.zeros_like(z)})
     else:
+        print("No Extra Args provided")
         model(z, pos, batch=batch)
 
 
 @mark.parametrize("model_name", models.__all_models__)
 @mark.parametrize("output_model", output_modules.__all__)
-@mark.parametrize("precision", [32,64])
+@mark.parametrize("precision", [32, 64])
 def test_forward_output_modules(model_name, output_model, precision):
     z, pos, batch = create_example_batch()
     args = load_example_args(model_name, remove_prior=True, output_model=output_model, precision=precision)

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -26,6 +26,8 @@ def load_example_args(model_name, remove_prior=False, config_file=None, **kwargs
         args["box_vecs"] = None
     if "remove_ref_energy" not in args:
         args["remove_ref_energy"] = False
+    if "additional_labels" not in args:
+        args["additional_labels"] = None
     for key, val in kwargs.items():
         assert key in args, f"Broken test! Unknown key '{key}'."
         args[key] = val

--- a/torchmdnet/datasets/ace.py
+++ b/torchmdnet/datasets/ace.py
@@ -273,7 +273,7 @@ class Ace(MemmappedDataset):
 
                     # Create a sample
                     args = dict(
-                        z=z, pos=pos, y=y.view(1, 1), neg_dy=neg_dy, q=q, pq=pq, dp=dp
+                        z=z, pos=pos, y=y.view(1, 1), neg_dy=neg_dy, total_charge=q, partial_charges=pq, dipole_moment=dp
                     )
                     if mol_ids:
                         args["mol_id"] = mol_id

--- a/torchmdnet/datasets/hdf.py
+++ b/torchmdnet/datasets/hdf.py
@@ -57,6 +57,15 @@ class HDF5(Dataset):
                             self.fields.append(
                                 ("partial_charges", "partial_charges", torch.float32)
                             )
+                        # total charge and spin, will be load as 'q' and 's' respectively to keep the same naming convention
+                        if "total_charge" in group:
+                            self.fields.append(
+                                ("total_charge", "total_charge", torch.float32)
+                            )
+                        if "spin" in group:
+                            self.fields.append(
+                                ("spin", "spin", torch.float32)
+                            )
                         assert ("energy" in group) or (
                             "forces" in group
                         ), "Each group must contain at least energies or forces"

--- a/torchmdnet/datasets/qm9q.py
+++ b/torchmdnet/datasets/qm9q.py
@@ -150,7 +150,7 @@ class QM9q(MemmappedDataset):
 
                     # Create a sample
                     args = dict(
-                        z=z, pos=pos, y=y.view(1, 1), neg_dy=neg_dy, q=q, pq=pq, dp=dp
+                        z=z, pos=pos, y=y.view(1, 1), neg_dy=neg_dy, total_charge=q, partial_charges=pq, dipole_moment=dp
                     )
                     if mol_ids:
                         args["mol_id"] = mol_id

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -387,25 +387,14 @@ class TorchMD_Net(nn.Module):
 
         if self.derivative:
             pos.requires_grad_(True)
-        
-        if self.representation_model.additional_methods is None:
-            extra_args_nnp = None 
-        else:
-            extra_args_nnp = {}
-            # force the label to be atom wise
-            for label, t in extra_args.items():
-                if label in self.representation_model.additional_methods.keys():
-                    if t.shape != z.shape:
-                        t = t[batch]
-                    extra_args_nnp[label] = t
-                    
+                   
         # run the potentially wrapped representation model
         x, v, z, pos, batch = self.representation_model(
             z,
             pos,
             batch,
             box=box,
-            extra_args=extra_args_nnp,
+            extra_args=extra_args if self.representation_model.additional_methods else None,
         )
         # apply the output network
         x = self.output_model.pre_reduce(x, v, z, pos, batch)

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -379,7 +379,7 @@ class TorchMD_Net(nn.Module):
         batch = torch.zeros_like(z) if batch is None else batch
 
         # trick to incorporate SPICE pqs
-        # set charge: true in yaml
+        # set charge: true in yaml ((?) currently I do it)
         q = extra_args["pq"]
         
         if self.derivative:

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -47,7 +47,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
         additional_labels = args["additional_labels"]
     else:
         additional_labels = None
-        warnings.warn("Extra fields should be a dictionary. Ignoring extra fields.")
+        warnings.warn("Additional labels should be a dictionary. Ignoring additional labels.")
         
     shared_args = dict(
         hidden_channels=args["embedding_dimension"],

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -388,13 +388,22 @@ class TorchMD_Net(nn.Module):
         if self.derivative:
             pos.requires_grad_(True)
         
+        if self.representation_model.additional_methods is not None:
+            extra_args_nnp = {}
+            # force the label to be atom wise
+            for label, t in extra_args.items():
+                if label in self.representation_model.additional_methods.keys():
+                    if t.shape != z.shape:
+                        t = t[batch]
+                    extra_args_nnp[label] = t
+                    
         # run the potentially wrapped representation model
         x, v, z, pos, batch = self.representation_model(
             z,
             pos,
             batch,
             box=box,
-            extra_args=extra_args,
+            extra_args=extra_args_nnp,
         )
         # apply the output network
         x = self.output_model.pre_reduce(x, v, z, pos, batch)

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -378,6 +378,10 @@ class TorchMD_Net(nn.Module):
         assert z.dim() == 1 and z.dtype == torch.long
         batch = torch.zeros_like(z) if batch is None else batch
 
+        # trick to incorporate SPICE pqs
+        # set charge: true in yaml
+        q = extra_args["pq"]
+        
         if self.derivative:
             pos.requires_grad_(True)
         # run the potentially wrapped representation model

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -40,16 +40,15 @@ def create_model(args, prior_model=None, mean=None, std=None):
         args["vector_cutoff"] = False
     
     # Here we introduce the extra_fields_args, which is Dict[str, Any]
-    # These could be used from each model to initialize nn.embedding layers, nn.Parameter, etc.
-    if "extra_fields" not in args:
-        extra_fields = None
-    elif isinstance(args["extra_fields"], str):
-        extra_fields = {args["extra_fields"]: None}
-    elif isinstance(args["extra_fields"], list):
-        extra_fields = {label: None for label in args["extra_fields"]}
+    # This could be used from each model to initialize nn.embedding layers, nn.Parameter, etc.
+    if "additional_labels" not in args:
+        additional_labels = None
+    elif isinstance(args["additional_labels"], dict):
+        additional_labels = args["additional_labels"]
     else:
-        extra_fields = args["extra_fields"]
-    
+        additional_labels = None
+        warnings.warn("Extra fields should be a dictionary. Ignoring extra fields.")
+        
     shared_args = dict(
         hidden_channels=args["embedding_dimension"],
         num_layers=args["num_layers"],
@@ -68,7 +67,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
             else None
         ),
         dtype=dtype,
-        extra_fields=extra_fields,
+        additional_labels=additional_labels,
     )
 
     # representation network

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -410,7 +410,6 @@ class TorchMD_Net(nn.Module):
             pos,
             batch,
             box=box,
-            extra_args=extra_args,
             extra_fields_args=extra_fields_args,
         )
         # apply the output network

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -348,7 +348,7 @@ class TorchMD_Net(nn.Module):
         pos: Tensor,
         batch: Optional[Tensor] = None,
         box: Optional[Tensor] = None,
-        extra_args: Optional[Dict[str, Optional[Tensor]]] = None,
+        extra_args: Optional[Dict[str, Tensor]] = None,
         extra_fields: Optional[Dict[str, Any]] = None,
     ) -> Tuple[Tensor, Tensor]:
         """

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -388,7 +388,9 @@ class TorchMD_Net(nn.Module):
         if self.derivative:
             pos.requires_grad_(True)
         
-        if self.representation_model.additional_methods is not None:
+        if self.representation_model.additional_methods is None:
+            extra_args_nnp = None 
+        else:
             extra_args_nnp = {}
             # force the label to be atom wise
             for label, t in extra_args.items():

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -167,7 +167,7 @@ class TensorNet(nn.Module):
         self.cutoff_lower = cutoff_lower
         self.cutoff_upper = cutoff_upper
         self.additional_labels = additional_labels
-        # initialize additional methods as None if not provided
+        # initialize additional methods as None if not provided, also used by module.py 
         self.additional_methods = None
         
         if additional_labels is not None:
@@ -345,7 +345,7 @@ class TensorEmbedding(nn.Module):
             linear.reset_parameters()
         self.init_norm.reset_parameters()
 
-    def _get_atomic_number_message(self, z: Tensor, edge_index: Tensor, extra_fields_args: Optional[Dict[str, Tensor]]) -> Tensor:
+    def _get_atomic_number_message(self, z: Tensor, edge_index: Tensor) -> Tensor:
         Z = self.emb(z)
         Zij = self.emb2(
             Z.index_select(0, edge_index.t().reshape(-1)).view(

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -522,8 +522,6 @@ class Interaction(nn.Module):
         A = self.linears_tensor[4](A.permute(0, 2, 3, 1)).permute(0, 3, 1, 2)
         S = self.linears_tensor[5](S.permute(0, 2, 3, 1)).permute(0, 3, 1, 2) # shape: (natoms, hidden_channels, 3, 3)
         dX = I + A + S
-        for label in self.additional_labels.keys():
-            assert label in extra_args, f"Extra field {label} not found in extra_args"
         X = X + dX + (prefactor) * torch.matrix_power(dX, 2)
         return X
 

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -187,7 +187,6 @@ class TensorNet(nn.Module):
             act_class,
             cutoff_lower,
             cutoff_upper,
-            trainable_rbf,
             max_z,
             dtype,
         )
@@ -303,7 +302,6 @@ class TensorEmbedding(nn.Module):
         activation,
         cutoff_lower,
         cutoff_upper,
-        trainable_rbf=False,
         max_z=128,
         dtype=torch.float32,
     ):

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -507,7 +507,7 @@ class Interaction(nn.Module):
         if self.addtional_methods is not None:
             for label, method in self.addtional_methods.items():
                 tmp_ = method.forward(extra_args[label][..., None, None, None])
-                prefactor *=  tmp_
+                prefactor +=  tmp_
                 
         if self.equivariance_invariance_group == "O(3)":
             A = torch.matmul(msg, Y)

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -503,7 +503,7 @@ class Interaction(nn.Module):
         )
         msg = Im + Am + Sm
         
-        prefactor = 1 if self.addtional_methods is not None else torch.ones_like(msg)
+        prefactor = 1 if self.addtional_methods is not None else torch.ones_like(msg).to(msg.device).to(msg.dtype)
         if self.addtional_methods is not None:
             for label, method in self.addtional_methods.items():
                 tmp_ = method.forward(extra_args[label][..., None, None, None])

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -258,7 +258,13 @@ class TensorNet(nn.Module):
         ), "Distance module did not return directional information"
         # Distance module returns -1 for non-existing edges, to avoid having to resize the tensors when we want to ensure static shapes (for CUDA graphs) we make all non-existing edges pertain to a ghost atom
         zp = z
- 
+        if extra_args is not None:
+            # we are assuming that extra args will be used, see model.py forward method how extra_args is passed
+            for label, t in extra_args.items():
+                # molecule wise --> atom wise 
+                if t.shape != z.shape:
+                    extra_args[label] = t[batch]
+            
         if self.static_shapes:
             mask = (edge_index[0] < 0).unsqueeze(0).expand_as(edge_index)
             zp = torch.cat((z, torch.zeros(1, device=z.device, dtype=z.dtype)), dim=0)

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -120,7 +120,10 @@ class TensorNet(nn.Module):
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
         additional_labels (Dict[str, Any], optional): Define the additional method to be used by the model, and the parameters to initialize it.
-            additional_labels = {method_name1: {label_name1: values}, method_name2:{ label_name2: values}, ...}
+            example:
+            additional_labels = {method_name1: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2}, 
+                                 method_name2: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2},
+                                 ...}
             (default: :obj:`None`)
     """
 

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -503,7 +503,7 @@ class Interaction(nn.Module):
         )
         msg = Im + Am + Sm
         
-        prefactor = 1 if self.addtional_methods is not None else torch.ones_like(msg).to(msg.device).to(msg.dtype)
+        prefactor = 1 if self.addtional_methods is not None else torch.ones_like(msg, device=msg.device, dtype=msg.dtype)
         if self.addtional_methods is not None:
             for label, method in self.addtional_methods.items():
                 tmp_ = method.forward(extra_args[label][..., None, None, None])

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -529,10 +529,9 @@ class Interaction(nn.Module):
 class TensornetQ(nn.Module):
   def __init__(self, init_value, additional_label='total_charge', learnable=False):
     super().__init__()
-    self.prmtr = nn.Parameter(init_value, requires_grad=learnable, dtype=torch.float32)
+    self.prmtr = nn.Parameter(torch.tensor(init_value), requires_grad=learnable)
     self.allowed_labels = ['total_charge', 'partial_charges']
     assert additional_label in self.allowed_labels, f"Label {additional_label} not allowed for this method"
-    self.additional_label = additional_label
-
+    
   def forward(self, X):
     return self.prmtr * X

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -239,7 +239,8 @@ class TensorNet(nn.Module):
         # Total charge q is a molecule-wise property. We transform it into an atom-wise property, with all atoms belonging to the same molecule being assigned the same charge q
         if q is None:
             q = torch.zeros_like(z, device=z.device, dtype=z.dtype)
-        else:
+        # if not atom-wise, make atom-wise (pq is already atom-wise)
+        if z.shape != q.shape:
             q = q[batch]
         zp = z
         if self.static_shapes:

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -120,7 +120,7 @@ class TensorNet(nn.Module):
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
         additional_labels (Dict[str, Any], optional): Define the additional method to be used by the model, and the parameters to initialize it.
-            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
+            additional_labels = {method_name1: {label_name1: values}, method_name2:{ label_name2: values}, ...}
             (default: :obj:`None`)
     """
 

--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -478,6 +478,7 @@ class Interaction(nn.Module):
             linear.reset_parameters()
         for linear in self.linears_tensor:
             linear.reset_parameters()
+        # TODO: should we reset the parameters of the additional methods here?
 
     def forward(
         self,
@@ -511,7 +512,7 @@ class Interaction(nn.Module):
         msg = Im + Am + Sm
         
         prefactor = 1 if self.addtional_methods is not None else torch.ones_like(msg, device=msg.device, dtype=msg.dtype)
-        if self.addtional_methods is not None:
+        if self.addtional_methods is not None and extra_args is not None:
             for label, method_dict in self.addtional_methods.items():
                 # appending to this list all the methods will be working in this way    
                 if method_dict['name'] in ['tensornet_q']:

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -80,7 +80,7 @@ class TorchMD_ET(nn.Module):
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
         extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
-            for example extra_labels={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_labels={'total_charge': {embedding_dims: 64}. 
+            for example extra_fields={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_fields={'total_charge': {embedding_dims: 64}. 
             default: :obj:`None`)
 
     """

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -139,7 +139,7 @@ class TorchMD_ET(nn.Module):
         self.dtype = dtype
         self.additional_labels = additional_labels
         self.allowed_additional_labels = None
-        self.provided_additional_methods = None
+        self.additional_methods = None
 
         act_class = act_class_mapping[activation]
 

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT License.
 # (See accompanying file README.md file or copy at http://opensource.org/licenses/MIT)
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 import torch
 from torch import Tensor, nn
 from torchmdnet.models.utils import (
@@ -102,6 +102,7 @@ class TorchMD_ET(nn.Module):
         box_vecs=None,
         vector_cutoff=False,
         dtype=torch.float32,
+        extra_fields=None,
     ):
         super(TorchMD_ET, self).__init__()
 
@@ -194,8 +195,7 @@ class TorchMD_ET(nn.Module):
         pos: Tensor,
         batch: Tensor,
         box: Optional[Tensor] = None,
-        q: Optional[Tensor] = None,
-        s: Optional[Tensor] = None,
+        extra_fields_args: Optional[Dict[str, Tensor]] = None,
     ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         x = self.embedding(z)
 

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -79,10 +79,10 @@ class TorchMD_ET(nn.Module):
             (default: :obj:`False`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
-            for example extra_fields={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_fields={'total_charge': {embedding_dims: 64}. 
-            default: :obj:`None`)
-
+        additional_labels (Dict[str, Any], optional): Additional labels to be passed to the forward method of the model: 
+            example: 
+            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
+            (default: :obj:`None`)
     """
 
     def __init__(
@@ -105,7 +105,7 @@ class TorchMD_ET(nn.Module):
         box_vecs=None,
         vector_cutoff=False,
         dtype=torch.float32,
-        extra_fields=None,
+        additional_labels=None,
     ):
         super(TorchMD_ET, self).__init__()
 
@@ -137,7 +137,9 @@ class TorchMD_ET(nn.Module):
         self.cutoff_upper = cutoff_upper
         self.max_z = max_z
         self.dtype = dtype
-        self.extra_fields = extra_fields
+        self.additional_labels = additional_labels
+        self.allowed_additional_labels = None
+        self.provided_additional_methods = None
 
         act_class = act_class_mapping[activation]
 
@@ -199,7 +201,7 @@ class TorchMD_ET(nn.Module):
         pos: Tensor,
         batch: Tensor,
         box: Optional[Tensor] = None,
-        extra_fields_args: Optional[Dict[str, Tensor]] = None,
+        extra_args: Optional[Dict[str, Tensor]] = None,
     ) -> Tuple[Tensor, Tensor, Tensor, Tensor, Tensor]:
         x = self.embedding(z)
 

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -79,6 +79,9 @@ class TorchMD_ET(nn.Module):
             (default: :obj:`False`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
+        extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
+            for example extra_labels={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_labels={'total_charge': {embedding_dims: 64}. 
+            default: :obj:`None`)
 
     """
 

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -137,6 +137,7 @@ class TorchMD_ET(nn.Module):
         self.cutoff_upper = cutoff_upper
         self.max_z = max_z
         self.dtype = dtype
+        self.extra_fields = extra_fields
 
         act_class = act_class_mapping[activation]
 

--- a/torchmdnet/models/torchmd_et.py
+++ b/torchmdnet/models/torchmd_et.py
@@ -79,9 +79,11 @@ class TorchMD_ET(nn.Module):
             (default: :obj:`False`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        additional_labels (Dict[str, Any], optional): Additional labels to be passed to the forward method of the model: 
-            example: 
-            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
+        additional_labels (Dict[str, Any], optional): Define the additional method to be used by the model, and the parameters to initialize it.
+            example:
+            additional_labels = {method_name1: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2}, 
+                                 method_name2: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2},
+                                 ...}
             (default: :obj:`None`)
     """
 

--- a/torchmdnet/models/torchmd_gn.py
+++ b/torchmdnet/models/torchmd_gn.py
@@ -140,7 +140,7 @@ class TorchMD_GN(nn.Module):
         self.cutoff_upper = cutoff_upper
         self.max_z = max_z
         self.aggr = aggr
-
+        self.extra_fields = extra_fields
         act_class = act_class_mapping[activation]
 
         self.embedding = nn.Embedding(self.max_z, hidden_channels, dtype=dtype)

--- a/torchmdnet/models/torchmd_gn.py
+++ b/torchmdnet/models/torchmd_gn.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT License.
 # (See accompanying file README.md file or copy at http://opensource.org/licenses/MIT)
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 import torch
 from torch import Tensor, nn
 from torchmdnet.models.utils import (
@@ -86,6 +86,9 @@ class TorchMD_GN(nn.Module):
             (default: :obj:`None`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
+        extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
+            for example extra_fields={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_fields={'total_charge': {embedding_dims: 64}. 
+            default: :obj:`None`)
 
     """
 
@@ -107,6 +110,7 @@ class TorchMD_GN(nn.Module):
         aggr="add",
         dtype=torch.float32,
         box_vecs=None,
+        extra_fields=None
     ):
         super(TorchMD_GN, self).__init__()
 
@@ -196,8 +200,7 @@ class TorchMD_GN(nn.Module):
         pos: Tensor,
         batch: Tensor,
         box: Optional[Tensor] = None,
-        s: Optional[Tensor] = None,
-        q: Optional[Tensor] = None,
+        extra_fields_args: Optional[Dict[str, Tensor]] = None,
     ) -> Tuple[Tensor, Optional[Tensor], Tensor, Tensor, Tensor]:
         x = self.embedding(z)
 

--- a/torchmdnet/models/torchmd_gn.py
+++ b/torchmdnet/models/torchmd_gn.py
@@ -143,7 +143,7 @@ class TorchMD_GN(nn.Module):
         self.aggr = aggr
         self.additional_labels = additional_labels
         self.allowed_additional_labels = None
-        self.provided_additional_methods = None        
+        self.additional_methods = None        
         
         act_class = act_class_mapping[activation]
 

--- a/torchmdnet/models/torchmd_gn.py
+++ b/torchmdnet/models/torchmd_gn.py
@@ -86,9 +86,10 @@ class TorchMD_GN(nn.Module):
             (default: :obj:`None`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
-            for example extra_fields={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_fields={'total_charge': {embedding_dims: 64}. 
-            default: :obj:`None`)
+        additional_labels (Dict[str, Any], optional): Additional labels to be passed to the forward method of the model: 
+            example: 
+            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
+            (default: :obj:`None`)
 
     """
 
@@ -110,7 +111,7 @@ class TorchMD_GN(nn.Module):
         aggr="add",
         dtype=torch.float32,
         box_vecs=None,
-        extra_fields=None
+        additional_labels=None
     ):
         super(TorchMD_GN, self).__init__()
 
@@ -140,7 +141,10 @@ class TorchMD_GN(nn.Module):
         self.cutoff_upper = cutoff_upper
         self.max_z = max_z
         self.aggr = aggr
-        self.extra_fields = extra_fields
+        self.additional_labels = additional_labels
+        self.allowed_additional_labels = None
+        self.provided_additional_methods = None        
+        
         act_class = act_class_mapping[activation]
 
         self.embedding = nn.Embedding(self.max_z, hidden_channels, dtype=dtype)
@@ -200,7 +204,7 @@ class TorchMD_GN(nn.Module):
         pos: Tensor,
         batch: Tensor,
         box: Optional[Tensor] = None,
-        extra_fields_args: Optional[Dict[str, Tensor]] = None,
+        extra_args: Optional[Dict[str, Tensor]] = None,
     ) -> Tuple[Tensor, Optional[Tensor], Tensor, Tensor, Tensor]:
         x = self.embedding(z)
 

--- a/torchmdnet/models/torchmd_gn.py
+++ b/torchmdnet/models/torchmd_gn.py
@@ -86,10 +86,11 @@ class TorchMD_GN(nn.Module):
             (default: :obj:`None`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        additional_labels (Dict[str, Any], optional): Additional labels to be passed to the forward method of the model: 
-            example: 
-            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
-            (default: :obj:`None`)
+        additional_labels (Dict[str, Any], optional): Define the additional method to be used by the model, and the parameters to initialize it.
+            example:
+            additional_labels = {method_name1: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2}, 
+                                 method_name2: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2},
+                                 ...}
 
     """
 

--- a/torchmdnet/models/torchmd_t.py
+++ b/torchmdnet/models/torchmd_t.py
@@ -76,10 +76,11 @@ class TorchMD_T(nn.Module):
             (default: :obj:`None`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        additional_labels (Dict[str, Any], optional): Additional labels to be passed to the forward method of the model: 
-            example: 
-            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
-            (default: :obj:`None`)
+        additional_labels (Dict[str, Any], optional): Define the additional method to be used by the model, and the parameters to initialize it.
+            example:
+            additional_labels = {method_name1: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2}, 
+                                 method_name2: {label_name: 'extra_arg_label', 'method_prm1': method_prm1,  'method_prm2': method_prm2},
+                                 ...}
     """
 
     def __init__(

--- a/torchmdnet/models/torchmd_t.py
+++ b/torchmdnet/models/torchmd_t.py
@@ -76,10 +76,10 @@ class TorchMD_T(nn.Module):
             (default: :obj:`None`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
-        extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
-            for example extra_fields={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_fields={'total_charge': {embedding_dims: 64}. 
-            default: :obj:`None`)
-
+        additional_labels (Dict[str, Any], optional): Additional labels to be passed to the forward method of the model: 
+            example: 
+            additional_labels = {method_name: {label_name1: values, label_name2: values, ...}, ...}
+            (default: :obj:`None`)
     """
 
     def __init__(
@@ -101,7 +101,7 @@ class TorchMD_T(nn.Module):
         max_num_neighbors=32,
         dtype=torch.float,
         box_vecs=None,
-        extra_fields=None
+        additional_labels=None
     ):
         super(TorchMD_T, self).__init__()
 
@@ -128,8 +128,9 @@ class TorchMD_T(nn.Module):
         self.cutoff_lower = cutoff_lower
         self.cutoff_upper = cutoff_upper
         self.max_z = max_z
-        self.extra_fields = extra_fields
-
+        self.additional_labels = additional_labels
+        self.allowed_additional_labels = None
+        self.provided_additional_methods = None
         act_class = act_class_mapping[activation]
         attn_act_class = act_class_mapping[attn_activation]
 

--- a/torchmdnet/models/torchmd_t.py
+++ b/torchmdnet/models/torchmd_t.py
@@ -196,7 +196,7 @@ class TorchMD_T(nn.Module):
         pos: Tensor,
         batch: Tensor,
         box: Optional[Tensor] = None,
-        extra_fields_args: Optional[Dict[str, Tensor]] = None
+        extra_args: Optional[Dict[str, Tensor]] = None
     ) -> Tuple[Tensor, Optional[Tensor], Tensor, Tensor, Tensor]:
         x = self.embedding(z)
 

--- a/torchmdnet/models/torchmd_t.py
+++ b/torchmdnet/models/torchmd_t.py
@@ -2,7 +2,7 @@
 # Distributed under the MIT License.
 # (See accompanying file README.md file or copy at http://opensource.org/licenses/MIT)
 
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 import torch
 from torch import Tensor, nn
 from torchmdnet.models.utils import (
@@ -76,6 +76,9 @@ class TorchMD_T(nn.Module):
             (default: :obj:`None`)
         check_errors (bool, optional): Whether to check for errors in the distance module.
             (default: :obj:`True`)
+        extra_fields (Dict[str, Any], optional): Extra fields to be passed to the model, the value could be a dict with some extra args to be passed to the model, 
+            for example extra_fields={'total_charge': {initial_value: 0.0, learnable: True}} or maybe extra_fields={'total_charge': {embedding_dims: 64}. 
+            default: :obj:`None`)
 
     """
 
@@ -98,6 +101,7 @@ class TorchMD_T(nn.Module):
         max_num_neighbors=32,
         dtype=torch.float,
         box_vecs=None,
+        extra_fields=None
     ):
         super(TorchMD_T, self).__init__()
 
@@ -190,8 +194,7 @@ class TorchMD_T(nn.Module):
         pos: Tensor,
         batch: Tensor,
         box: Optional[Tensor] = None,
-        s: Optional[Tensor] = None,
-        q: Optional[Tensor] = None,
+        extra_fields_args: Optional[Dict[str, Tensor]] = None
     ) -> Tuple[Tensor, Optional[Tensor], Tensor, Tensor, Tensor]:
         x = self.embedding(z)
 

--- a/torchmdnet/models/torchmd_t.py
+++ b/torchmdnet/models/torchmd_t.py
@@ -128,6 +128,7 @@ class TorchMD_T(nn.Module):
         self.cutoff_lower = cutoff_lower
         self.cutoff_upper = cutoff_upper
         self.max_z = max_z
+        self.extra_fields = extra_fields
 
         act_class = act_class_mapping[activation]
         attn_act_class = act_class_mapping[attn_activation]

--- a/torchmdnet/models/torchmd_t.py
+++ b/torchmdnet/models/torchmd_t.py
@@ -130,7 +130,7 @@ class TorchMD_T(nn.Module):
         self.max_z = max_z
         self.additional_labels = additional_labels
         self.allowed_additional_labels = None
-        self.provided_additional_methods = None
+        self.additional_methods = None
         act_class = act_class_mapping[activation]
         attn_act_class = act_class_mapping[attn_activation]
 

--- a/torchmdnet/models/wrappers.py
+++ b/torchmdnet/models/wrappers.py
@@ -3,7 +3,7 @@
 # (See accompanying file README.md file or copy at http://opensource.org/licenses/MIT)
 
 from abc import abstractmethod, ABCMeta
-from typing import Optional, Tuple
+from typing import Optional, Tuple, Dict
 from torch import nn, Tensor
 
 
@@ -43,10 +43,9 @@ class AtomFilter(BaseWrapper):
         z: Tensor,
         pos: Tensor,
         batch: Tensor,
-        q: Optional[Tensor] = None,
-        s: Optional[Tensor] = None,
+        extra_args: Optional[Dict[str, Tensor]] = None,
     ) -> Tuple[Tensor, Optional[Tensor], Tensor, Tensor, Tensor]:
-        x, v, z, pos, batch = self.model(z, pos, batch=batch, q=q, s=s)
+        x, v, z, pos, batch = self.model(z, pos, batch=batch, extra_args=extra_args)
 
         n_samples = len(batch.unique())
 

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -60,6 +60,7 @@ def get_argparse():
     parser.add_argument('--gradient-clipping', type=float, default=0.0, help='Gradient clipping norm')
     parser.add_argument('--remove-ref-energy', action='store_true', help='If true, remove the reference energy from the dataset for delta-learning. Total energy can still be predicted by the model during inference by turning this flag off when loading.  The dataset must be compatible with Atomref for this to be used.')
     # dataset specific
+    parser.add_argument('--extra-fields', default=None, help='Extra fields of the dataset to pass to the model, it could be a list of fields or a dictionary with the field name and addtionals arguments')
     parser.add_argument('--dataset', default=None, type=str, choices=datasets.__all__, help='Name of the torch_geometric dataset')
     parser.add_argument('--dataset-root', default='~/data', type=str, help='Data storage directory (not used if dataset is "CG")')
     parser.add_argument('--dataset-arg', default=None, help='Additional dataset arguments. Needs to be a dictionary.')

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -60,7 +60,7 @@ def get_argparse():
     parser.add_argument('--gradient-clipping', type=float, default=0.0, help='Gradient clipping norm')
     parser.add_argument('--remove-ref-energy', action='store_true', help='If true, remove the reference energy from the dataset for delta-learning. Total energy can still be predicted by the model during inference by turning this flag off when loading.  The dataset must be compatible with Atomref for this to be used.')
     # dataset specific
-    parser.add_argument('--extra-fields', default=None, help='Extra fields of the dataset to pass to the model, it could be a list of fields or a dictionary with the field name and addtionals arguments')
+    parser.add_argument('--additional-labels', default=None, help='Additional labels to be passed to the model, must be a dict like {"method_name":{args}}')    
     parser.add_argument('--dataset', default=None, type=str, choices=datasets.__all__, help='Name of the torch_geometric dataset')
     parser.add_argument('--dataset-root', default='~/data', type=str, help='Data storage directory (not used if dataset is "CG")')
     parser.add_argument('--dataset-arg', default=None, help='Additional dataset arguments. Needs to be a dictionary.')

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -77,8 +77,6 @@ def get_argparse():
     parser.add_argument('--prior-model', type=str, default=None, help='Which prior model to use. It can be a string, a dict if you want to add arguments for it or a dicts to add more than one prior. e.g. {"Atomref": {"max_z":100}, "Coulomb":{"max_num_neighs"=100, "lower_switch_distance"=4, "upper_switch_distance"=8}', action="extend", nargs="*")
 
     # architectural args
-    parser.add_argument('--charge', type=bool, default=False, help='Model needs a total charge. Set this to True if your dataset contains charges and you want them passed down to the model.')
-    parser.add_argument('--spin', type=bool, default=False, help='Model needs a spin state. Set this to True if your dataset contains spin states and you want them passed down to the model.')
     parser.add_argument('--embedding-dimension', type=int, default=256, help='Embedding dimension')
     parser.add_argument('--num-layers', type=int, default=6, help='Number of interaction layers in the model')
     parser.add_argument('--num-rbf', type=int, default=64, help='Number of radial basis functions in model')


### PR DESCRIPTION
 This PR proposes several enhancements to enable the usage of extra arguments in both training and inference. The key modifications include
- [x] standardizing the naming conventions for all extra fields across different data loaders;
- [x] removing q and s as explicit args in the forward;
- [x] introducing additional labels through a new dictionary for model initialization, example:
```
additional_labels:
     tensornetq:
        label: total_charge
        learnable: true
        init_value: 0.1
```
- [x] add TensornetQ nn.Module
- [x] extra args expansion from molecule-wise to atom-wise inside the model
- [x] tensornet_q tested with total_charge and partial_charges, reproducibility achieved   
- [x] rewrite some tests according to the new methods
At the moment only 'tensornet_q' supported as additional_methods but more can be added  