### PR TITLE
Fix HDF5 not understanding some files

### DIFF
--- a/torchmdnet/datasets/hdf.py
+++ b/torchmdnet/datasets/hdf.py
@@ -89,7 +89,7 @@ class HDF5(Dataset):
                         # Watchout for the 1D case, embed can be shared for all samples
                         tmp = torch.tensor(np.array(data), dtype=dtype)
                         if tmp.ndim == 1:
-                            tmp = tmp.unsqueeze(0).expand(size, -1)
+                            tmp = tmp.unsqueeze(-1)
                         self.stored_data[field].append(tmp)
                     self.index.extend(list(zip([i] * size, range(size))))
                     i += 1

--- a/torchmdnet/datasets/hdf.py
+++ b/torchmdnet/datasets/hdf.py
@@ -89,7 +89,10 @@ class HDF5(Dataset):
                         # Watchout for the 1D case, embed can be shared for all samples
                         tmp = torch.tensor(np.array(data), dtype=dtype)
                         if tmp.ndim == 1:
-                            tmp = tmp.unsqueeze(-1)
+                            if len(tmp) == size:
+                                tmp = tmp.unsqueeze(-1)
+                            else:
+                                tmp = tmp.unsqueeze(0).expand(size, -1)
                         self.stored_data[field].append(tmp)
                     self.index.extend(list(zip([i] * size, range(size))))
                     i += 1


### PR DESCRIPTION
HDF5 breaks backwards comp when preloading to cache if the user passes a dataset in which energy has shape (nsamples,) instead of (nsamples,1).
This PR fixes it.