### PR TITLE
Allow to configure the depth of the MLP in output modules 

### DIFF
--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -127,6 +127,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
         activation=args["activation"],
         reduce_op=args["reduce_op"],
         dtype=dtype,
+        num_layers=args.get("output_mlp_num_layers", 0),
     )
 
     # combine representation and output network

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -233,6 +233,13 @@ def load_model(filepath, args=None, device="cpu", return_std=False, **kwargs):
             model.prior_model[-1].enable = True
 
     state_dict = {re.sub(r"^model\.", "", k): v for k, v in ckpt["state_dict"].items()}
+    # In ET, before we had output_model.output_network.{0,1}.update_net.[0-9].{weight,bias}
+    # Now we have output_model.output_network.{0,1}.update_net.layers.[0-9].{weight,bias}
+    # This change was introduced in https://github.com/torchmd/torchmd-net/pull/314
+    state_dict = {
+        re.sub(r"update_net\.(\d+)\.", r"update_net.layers.\1.", k): v
+        for k, v in state_dict.items()
+    }
     model.load_state_dict(state_dict)
     return model.to(device)
 

--- a/torchmdnet/models/model.py
+++ b/torchmdnet/models/model.py
@@ -127,7 +127,7 @@ def create_model(args, prior_model=None, mean=None, std=None):
         activation=args["activation"],
         reduce_op=args["reduce_op"],
         dtype=dtype,
-        num_layers=args.get("output_mlp_num_layers", 0),
+        num_hidden_layers=args.get("output_mlp_num_layers", 0),
     )
 
     # combine representation and output network

--- a/torchmdnet/models/output_modules.py
+++ b/torchmdnet/models/output_modules.py
@@ -25,6 +25,7 @@ class OutputModel(nn.Module, metaclass=ABCMeta):
     Derive this class to make custom output models.
     As an example, have a look at the :py:mod:`torchmdnet.output_modules.Scalar` output model.
     """
+
     def __init__(self, allow_prior_model, reduce_op):
         super(OutputModel, self).__init__()
         self.allow_prior_model = allow_prior_model
@@ -75,7 +76,7 @@ class Scalar(OutputModel):
             out_channels=1,
             hidden_channels=hidden_channels // 2,
             activation=activation,
-            num_layers=kwargs.get("num_layers", 0),
+            num_hidden_layers=kwargs.get("num_layers", 0),
             dtype=dtype,
         )
         self.reset_parameters()
@@ -214,7 +215,7 @@ class ElectronicSpatialExtent(OutputModel):
             out_channels=1,
             hidden_channels=hidden_channels // 2,
             activation=activation,
-            num_layers=kwargs.get("num_layers", 0),
+            num_hidden_layers=kwargs.get("num_layers", 0),
             dtype=dtype,
         )
         atomic_mass = torch.from_numpy(atomic_masses).to(dtype)

--- a/torchmdnet/models/utils.py
+++ b/torchmdnet/models/utils.py
@@ -437,12 +437,21 @@ class CosineCutoff(nn.Module):
 class MLP(nn.Module):
     """A simple multi-layer perceptron with a given number of layers and hidden channels.
 
+    The simplest MLP has no hidden layers and is composed of two linear layers with a non-linear activation function in between:
+
+    .. math::
+
+        \text{MLP}(x) = \text{Linear}_o(\text{act}(\text{Linear}_i(x)))
+
+    Where :math:`\text{Linear}_i` has input size :math:`\text{in_channels}` and output size :math:`\text{hidden_channels}` and :math:`\text{Linear}_o` has input size :math:`\text{hidden_channels}` and output size :math:`\text{out_channels}`.
+
+
     Args:
         in_channels (int): Number of input features.
         out_channels (int): Number of output features.
         hidden_channels (int): Number of hidden features.
         activation (str): Activation function to use.
-        num_layers (int, optional): Number of layers. Defaults to 0.
+        num_hidden_layers (int, optional): Number of hidden layers. Defaults to 0.
         dtype (torch.dtype, optional): Data type to use. Defaults to torch.float32.
     """
 
@@ -452,7 +461,7 @@ class MLP(nn.Module):
         out_channels,
         hidden_channels,
         activation,
-        num_layers=0,
+        num_hidden_layers=0,
         dtype=torch.float32,
     ):
         super(MLP, self).__init__()
@@ -461,7 +470,7 @@ class MLP(nn.Module):
         self.layers = nn.Sequential()
         self.layers.append(nn.Linear(in_channels, hidden_channels, dtype=dtype))
         self.layers.append(self.act)
-        for _ in range(num_layers):
+        for _ in range(num_hidden_layers):
             self.layers.append(nn.Linear(hidden_channels, hidden_channels, dtype=dtype))
             self.layers.append(self.act)
         self.layers.append(nn.Linear(hidden_channels, out_channels, dtype=dtype))
@@ -510,7 +519,7 @@ class GatedEquivariantBlock(nn.Module):
             out_channels=out_channels * 2,
             hidden_channels=intermediate_channels,
             activation=activation,
-            num_layers=0,
+            num_hidden_layers=0,
             dtype=dtype,
         )
         self.act = act_class() if scalar_activation else None

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -74,7 +74,7 @@ def get_argparse():
     # model architecture
     parser.add_argument('--model', type=str, default='graph-network', choices=models.__all_models__, help='Which model to train')
     parser.add_argument('--output-model', type=str, default='Scalar', choices=output_modules.__all__, help='The type of output model')
-    parser.add_argument('--output-mlp-num-layers', type=int, default=0, help='If the output model uses an MLP this will be the number of inner layers.')
+    parser.add_argument('--output-mlp-num-layers', type=int, default=0, help='If the output model uses an MLP this will be the number of hidden layers, excluding the input and output layers.')
     parser.add_argument('--prior-model', type=str, default=None, help='Which prior model to use. It can be a string, a dict if you want to add arguments for it or a dicts to add more than one prior. e.g. {"Atomref": {"max_z":100}, "Coulomb":{"max_num_neighs"=100, "lower_switch_distance"=4, "upper_switch_distance"=8}', action="extend", nargs="*")
 
     # architectural args

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -74,6 +74,7 @@ def get_argparse():
     # model architecture
     parser.add_argument('--model', type=str, default='graph-network', choices=models.__all_models__, help='Which model to train')
     parser.add_argument('--output-model', type=str, default='Scalar', choices=output_modules.__all__, help='The type of output model')
+    parser.add_argument('--output-mlp-num-layers', type=int, default=0, help='If the output model uses an MLP this will be the number of inner layers.')
     parser.add_argument('--prior-model', type=str, default=None, help='Which prior model to use. It can be a string, a dict if you want to add arguments for it or a dicts to add more than one prior. e.g. {"Atomref": {"max_z":100}, "Coulomb":{"max_num_neighs"=100, "lower_switch_distance"=4, "upper_switch_distance"=8}', action="extend", nargs="*")
 
     # architectural args


### PR DESCRIPTION
Adds an MLP module to utils and uses it in the output models.

Allows to configure the depth of it via a train.py option, `output-mlp-num-layers` 