### PR TITLE
Enable allow_pickle to be able to specify splits.

### DIFF
--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -247,7 +247,7 @@ def make_splits(
     order=None,
 ):
     if splits is not None:
-        splits = np.load(splits)
+        splits = np.load(splits, allow_pickle=True)
         idx_train = splits["idx_train"]
         idx_val = splits["idx_val"]
         idx_test = splits["idx_test"]


### PR DESCRIPTION
I've been trying to train a torchmd-net model following the examples in the examples folder but I'm unable to specify my own splits. This is an easy fix that unblocks me and perhaps other users. If you know of a way to save the splits in a way that doesn't require us to enable allow_pickle I'd love to hear about it and we can close the PR. 

Full disclosure about the level of testing - this change allows me to get past the part of the code where the splits are loaded but I'm currently hitting other errors later, so I can't yet verify that the full script runs. 