### PR TITLE
Exponential moving averages of model parameters

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -17,3 +17,5 @@ dependencies:
   - pytest
   - psutil
   - gxx<12
+  - pip:
+    - torch-ema

--- a/torchmdnet/module.py
+++ b/torchmdnet/module.py
@@ -74,7 +74,10 @@ class LNNP(LightningModule):
         else:
             self.model = create_model(self.hparams, prior_model, mean, std)
 
-        self.ema_weights = ExponentialMovingAverage(self.model.parameters(), decay=0.995)
+        self.ema_prmtrs = None
+        if self.hparams.ema_prmtrs_decay is not None:
+            # initialize EMA for the model paremeters
+            self.ema_prmtrs = ExponentialMovingAverage(self.model.parameters(), decay=self.hparams.ema_prmtrs_decay)
         
         # initialize exponential smoothing
         self.ema = None
@@ -256,8 +259,9 @@ class LNNP(LightningModule):
         optimizer.zero_grad()
     
     def on_before_zero_grad(self, *args, **kwargs):
-        self.ema_weights.to(self.device)
-        self.ema_weights.update(self.model.parameters())
+        if self.ema_prmtrs is not None:
+            self.ema_prmtrs.to(self.device)
+            self.ema_prmtrs.update(self.model.parameters())
 
     def _get_mean_loss_dict_for_type(self, type):
         # Returns a list with the mean loss for each loss_fn for each stage (train, val, test)

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -59,6 +59,7 @@ def get_argparse():
     parser.add_argument('--redirect', type=bool, default=False, help='Redirect stdout and stderr to log_dir/log')
     parser.add_argument('--gradient-clipping', type=float, default=0.0, help='Gradient clipping norm')
     parser.add_argument('--remove-ref-energy', action='store_true', help='If true, remove the reference energy from the dataset for delta-learning. Total energy can still be predicted by the model during inference by turning this flag off when loading.  The dataset must be compatible with Atomref for this to be used.')
+    parser.add_argument('--ema-prmtrs-decay', type=float, default=None, help='Exponential moving average decay for model parameters (None to disable)')
     # dataset specific
     parser.add_argument('--dataset', default=None, type=str, choices=datasets.__all__, help='Name of the torch_geometric dataset')
     parser.add_argument('--dataset-root', default='~/data', type=str, help='Data storage directory (not used if dataset is "CG")')


### PR DESCRIPTION
Enhance model training by enabling Exponential Moving Average (EMA) on the model parameters. To activate this feature, simply specify the `ema_prmtrs_decay` arg in the configuration file. If not set, its default value is None, indicating that EMA is not going to be applied.