### PR TITLE
Disable persistent_workers with num_workers=0 and disable pin_memory in DataModule 

### DIFF
--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -134,7 +134,7 @@ class DataModule(LightningDataModule):
             batch_size=batch_size,
             num_workers=self.hparams["num_workers"],
             persistent_workers=True if self.hparams["num_workers"] > 0 else False,
-            pin_memory=True,
+            pin_memory=False,
             shuffle=shuffle,
         )
 

--- a/torchmdnet/data.py
+++ b/torchmdnet/data.py
@@ -133,7 +133,7 @@ class DataModule(LightningDataModule):
             dataset=dataset,
             batch_size=batch_size,
             num_workers=self.hparams["num_workers"],
-            persistent_workers=True,
+            persistent_workers=True if self.hparams["num_workers"] > 0 else False,
             pin_memory=True,
             shuffle=shuffle,
         )


### PR DESCRIPTION
currently I cannot set num_workers to zero:
```
ValueError:
persistent_workers option needs num_workers > 0
```
This was the fix suggested by @AntonioMirarchi that works for me

Closes #323
Closes #324 