### PR TITLE
Disable TF32 usage by default

### DIFF
--- a/torchmdnet/models/tensornet.py
+++ b/torchmdnet/models/tensornet.py
@@ -13,8 +13,6 @@ from torchmdnet.models.utils import (
 )
 
 __all__ = ["TensorNet"]
-torch.set_float32_matmul_precision("high")
-torch.backends.cuda.matmul.allow_tf32 = True
 
 
 def vector_to_skewtensor(vector):


### PR DESCRIPTION
Tensornet enables tf32 by default. We find these affect the accuracy too greatly in some situations so I am disabling them out of caution (which is the default in pytorch).
User code can request TF32 usage by writing this after importing torch:

```python
torch.set_float32_matmul_precision("high")
torch.backends.cuda.matmul.allow_tf32 = True
```