### PR TITLE
Add SPICE 2.0.1, Fix bug in MemmappedDataset

### DIFF
--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -291,8 +291,8 @@ def test_ace(tmpdir):
         mol["forces"].attrs["units"] = "eV/Å"
         mol["partial_charges"] = np.random.random((2, 3))
         mol["partial_charges"].attrs["units"] = "e"
-        mol["dipole_moment"] = np.random.random((2, 3))
-        mol["dipole_moment"].attrs["units"] = "e*Å"
+        mol["dipole_moments"] = np.random.random((2, 3))
+        mol["dipole_moments"].attrs["units"] = "e*Å"
     dataset_v2 = Ace(root=tmpdir, paths=tmpfilename_v2)
     assert len(dataset_v2) == 6
     f2.flush()

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -279,7 +279,7 @@ def test_ace(tmpdir):
     f2.attrs["layout_version"] = "2.0"
     f2.attrs["name"] = "sample_molecule_data_v2"
     master_mol_group = f2.create_group("master_molecule_group")
-    for m in range(3):  # Three molecules
+    for m in range(4):
         mol = master_mol_group.create_group(f"mol_{m+1}")
         mol["atomic_numbers"] = [1, 6, 8]  # H, C, O
         mol["formal_charges"] = [0, 0, 0]  # Neutral charges
@@ -294,6 +294,6 @@ def test_ace(tmpdir):
         mol["dipole_moments"] = np.random.random((2, 3))
         mol["dipole_moments"].attrs["units"] = "e*Å"
     dataset_v2 = Ace(root=tmpdir, paths=tmpfilename_v2)
-    assert len(dataset_v2) == 6
+    assert len(dataset_v2) == 8
     f2.flush()
     f2.close()

--- a/torchmdnet/datasets/memdataset.py
+++ b/torchmdnet/datasets/memdataset.py
@@ -57,7 +57,8 @@ class MemmappedDataset(Dataset):
         pre_filter=None,
         properties=("y", "neg_dy", "q", "pq", "dp"),
     ):
-        self.name = self.__class__.__name__
+        if not hasattr(self, "name"):
+            self.name = self.__class__.__name__
         self.properties = properties
         super().__init__(root, transform, pre_transform, pre_filter)
 

--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -68,6 +68,10 @@ class SPICE(MemmappedDataset):
             "url": "https://zenodo.org/records/8222043/files",
             "file": "SPICE-1.1.4.hdf5",
         },
+        "2.0.1": {
+            "url": "https://zenodo.org/records/10975225/files",
+            "file": "SPICE-2.0.1.hdf5",
+        },
     }
 
     @property

--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -76,7 +76,7 @@ class SPICE(MemmappedDataset):
 
     @property
     def raw_dir(self):
-        return os.path.join(super().raw_dir, self.version)
+        return os.path.join(super().raw_dir, "spice", self.version)
 
     @property
     def raw_file_names(self):

--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -10,6 +10,7 @@ import torch as pt
 from torchmdnet.datasets.memdataset import MemmappedDataset
 from torch_geometric.data import Data, download_url
 from tqdm import tqdm
+import logging
 
 
 class SPICE(MemmappedDataset):
@@ -141,7 +142,12 @@ class SPICE(MemmappedDataset):
                 * self.HARTREE_TO_EV
                 / self.BORH_TO_ANGSTROM
             )
-
+            if all_pos.ndim < 3:
+                logging.warning(f"Bogus conformation {mol_id}")
+                logging.warning(
+                    f"Found {all_pos.shape} positions, {all_y.shape} energies and {all_neg_dy.shape} gradients"
+                )
+                continue
             assert all_pos.shape[0] == all_y.shape[0]
             assert all_pos.shape[1] == z.shape[0]
             assert all_pos.shape[2] == 3

--- a/torchmdnet/datasets/spice.py
+++ b/torchmdnet/datasets/spice.py
@@ -56,22 +56,27 @@ class SPICE(MemmappedDataset):
         "1.1.1": {
             "url": "https://zenodo.org/record/7258940/files",
             "file": "SPICE-1.1.1.hdf5",
+            "hash": "5411e7014c6d18ff07d108c9ad820b53",
         },
         "1.1.2": {
             "url": "https://zenodo.org/record/7338495/files",
             "file": "SPICE-1.1.2.hdf5",
+            "hash": "a2b5ae2d1f72581040e1cceb20a79a33",
         },
         "1.1.3": {
             "url": "https://zenodo.org/record/7606550/files",
             "file": "SPICE-1.1.3.hdf5",
+            "hash": "be93706b3bb2b2e327b690b185905856",
         },
         "1.1.4": {
             "url": "https://zenodo.org/records/8222043/files",
             "file": "SPICE-1.1.4.hdf5",
+            "hash": "f27d4c81da0e37d6547276bf6b4ae6a1",
         },
         "2.0.1": {
             "url": "https://zenodo.org/records/10975225/files",
             "file": "SPICE-2.0.1.hdf5",
+            "hash": "bfba2224b6540e1390a579569b475510",
         },
     }
 
@@ -178,3 +183,7 @@ class SPICE(MemmappedDataset):
 
     def download(self):
         download_url(self.raw_url, self.raw_dir)
+        if "hash" in self.VERSIONS[self.version]:
+            with open(self.raw_paths[0], "rb") as f:
+                file_hash = hashlib.md5(f.read()).hexdigest()
+            assert file_hash == self.VERSIONS[self.version]["hash"]


### PR DESCRIPTION
Adds compatibility for the latest SPICE version https://arxiv.org/pdf/2406.13112

In doing so I uncovered a couple of issues related to MemmapedDataset.
### I fixed MemmapedDataset overwriting the names of processed datasets.
 In particular, SPICE sets self.name as:
```python
        arg_hash = f"{version}{subsets}{max_gradient}{subsample_molecules}"
        arg_hash = hashlib.md5(arg_hash.encode()).hexdigest()
        self.name = f"{self.__class__.__name__}-{arg_hash}"
``` 
Which gets overwritten in the MemmappedDataset constructor:
```python
self.name = self.__class__.__name__
```
Causing any subsample/gradient configurations to be stored as just "SPICE.*.mmap". Probably ignoring subsample/gradient if the dataset has been already processed.

### This in turn uncovered a nasty bug in the test for the ACE Dataset. 
Since all instances of the Dataset are named with just `self.__class__.__name__`, creating two instances of ACE will simply ignore the data in the second and use what was processed in the first to a group of files just called "Ace.*.mmap".
This test should not pass but it was passing until now:
https://github.com/torchmd/torchmd-net/blob/e908988440f2e9d77029a15c41fcee8139ee8b7f/tests/test_datasets.py#L246-L299
In Ace v2 the field is called `dipole_moments`. But MemmappedDataset was not even trying to process the second one.

### I also made some changes
- Now SPICE checks the hash of the downloaded files.
- Now SPICE stores files under `{root}/raw/spice/` or `{root}/processed/spice`. Before it was storing things under `{root}/raw/{version}`, which could collide with other datasets. 

**Note that this PR will invalidate many preprocessed datasets, prompting for redownloading and reprocessing**. I recommend you delete the dataset storage folder and let it redownload things.