### PR TITLE
Add backup for metrics.csv

### DIFF
--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -21,7 +21,7 @@ from torchmdnet.loss import loss_class_mapping
 from torchmdnet.models import output_modules
 from torchmdnet.models.model import create_prior_models
 from torchmdnet.models.utils import rbf_class_mapping, act_class_mapping, dtype_mapping
-from torchmdnet.utils import LoadFromFile, LoadFromCheckpoint, save_argparse, number
+from torchmdnet.utils import LoadFromFile, LoadFromCheckpoint, save_argparse, number, check_logs
 from lightning_utilities.core.rank_zero import rank_zero_warn
 
 
@@ -178,8 +178,9 @@ def main():
         auto_insert_metric_name=False,
     )
     early_stopping = EarlyStopping(val_loss_name, patience=args.early_stopping_patience)
-
     csv_logger = CSVLogger(args.log_dir, name="", version="")
+    check_logs(csv_logger)
+    
     _logger = [csv_logger]
     if args.wandb_use:
         wandb_logger = WandbLogger(

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -21,7 +21,13 @@ from torchmdnet.loss import loss_class_mapping
 from torchmdnet.models import output_modules
 from torchmdnet.models.model import create_prior_models
 from torchmdnet.models.utils import rbf_class_mapping, act_class_mapping, dtype_mapping
-from torchmdnet.utils import LoadFromFile, LoadFromCheckpoint, save_argparse, number, check_logs
+from torchmdnet.utils import (
+    LoadFromFile,
+    LoadFromCheckpoint,
+    save_argparse,
+    number,
+    check_logs,
+)
 from lightning_utilities.core.rank_zero import rank_zero_warn
 
 
@@ -178,10 +184,11 @@ def main():
         auto_insert_metric_name=False,
     )
     early_stopping = EarlyStopping(val_loss_name, patience=args.early_stopping_patience)
+
     csv_logger = CSVLogger(args.log_dir, name="", version="")
     check_logs(csv_logger)
-    
     _logger = [csv_logger]
+
     if args.wandb_use:
         wandb_logger = WandbLogger(
             project=args.wandb_project,

--- a/torchmdnet/scripts/train.py
+++ b/torchmdnet/scripts/train.py
@@ -184,9 +184,9 @@ def main():
         auto_insert_metric_name=False,
     )
     early_stopping = EarlyStopping(val_loss_name, patience=args.early_stopping_patience)
-
+    
+    check_logs(args.log_dir)
     csv_logger = CSVLogger(args.log_dir, name="", version="")
-    check_logs(csv_logger)
     _logger = [csv_logger]
 
     if args.wandb_use:

--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -397,3 +397,13 @@ def deprecated_class(cls):
 
     cls.__init__ = wrapped_init
     return cls
+
+def check_logs(csvlogger):
+    import os 
+    import time
+    metr_file_path = csvlogger.experiment.metrics_file_path
+    if os.path.exists(metr_file_path):
+        # we make a backup of the metrics file (rename)
+        bckp_date = f'{time.strftime("%Y%m%d")}-{time.strftime("%H%M%S")}'
+        os.rename(metr_file_path, metr_file_path.replace(".csv", f"_{bckp_date}.csv"))
+    return

--- a/torchmdnet/utils.py
+++ b/torchmdnet/utils.py
@@ -398,10 +398,10 @@ def deprecated_class(cls):
     cls.__init__ = wrapped_init
     return cls
 
-def check_logs(csvlogger):
+def check_logs(log_dir):
     import os 
     import time
-    metr_file_path = csvlogger.experiment.metrics_file_path
+    metr_file_path = os.path.join(log_dir, 'metrics.csv')
     if os.path.exists(metr_file_path):
         # we make a backup of the metrics file (rename)
         bckp_date = f'{time.strftime("%Y%m%d")}-{time.strftime("%H%M%S")}'


### PR DESCRIPTION
We currently use `CSVLogger` from `torch.lightning` to write metrics to a CSV file in the log directory. However, when using `load_model` (i.e., loading from a checkpoint), or more in general to append data to an existing CSV, we overwrite the current metrics.csv, losing the original data.
This PR introduces a simple function that checks if the metrics file already exists and renames it using date and time information, preserving previous data. 
Ideally, we would prefer to append to the existing file, but AFAIK this is not currently supported by CSVLogger. 

