### PR TITLE
Update setup.py to check if WITH_CUDA is set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,10 +9,13 @@ import os
 
 
 # If WITH_CUDA is defined
-if os.environ.get("WITH_CUDA", "0") == "1":
-    use_cuda = True
-elif os.environ.get("WITH_CUDA", "0") == "0":
-    use_cuda = False
+if os.getenv("WITH_CUDA") is None:
+    if os.environ.get("WITH_CUDA", "0") == "1":
+        use_cuda = True
+    elif os.environ.get("WITH_CUDA", "0") == "0":
+        use_cuda = False
+    else:
+        raise ValueError("Invalid flag with WITH_CUDA environment variable. Expected '0' or '1'")
 else:
     use_cuda = torch.cuda._is_compiled()
 


### PR DESCRIPTION
`os.environ.get("WITH_CUDA", "0") == "0"` return `True` even if the environment variable is not set. Thus currently, the default behavior is to automatically fall back to CPU-only build if `WITH_CUDA` is not set. 

This introduces a small change to the first check if the `WITH_CUDA` is set. If not set, it falls back to the build defined by `torch.cuda._is_compiled()`. 
